### PR TITLE
[zGALI] Public Spend with broken P1 proof

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -184,6 +184,7 @@ BITCOIN_CORE_H = \
   zgali/zerocoin.h \
   zgali/zgalitracker.h \
   zgali/zgaliwallet.h \
+  zgali/zgalimodule.h \
   genwit.h \
   concurrentqueue.h \
   lightzgalithread.h \
@@ -280,6 +281,7 @@ libbitcoin_wallet_a_SOURCES = \
   zgali/zgalitracker.cpp \
   stakeinput.cpp \
   genwit.cpp \
+  zgali/zgalimodule.cpp \
   lightzgalithread.cpp \
   $(BITCOIN_CORE_H)
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -145,6 +145,9 @@ public:
         nEnforceNewSporkKey = 1553907600;		/* Sat Mar 30 01:00:00 UTC 2019: sporks signed after must use the new spork key */
         nRejectOldSporkKey = 1554080400;		/* Mon Apr  1 01:00:00 UTC 2019: after that reject old spork key */
 
+        // Public coin spend enforcement
+        nPublicZCSpends = 626000;
+
         /**
          * Build the genesis block. Note that the output of the genesis coinbase cannot
          * be spent as it did not originally exist in the database.
@@ -217,6 +220,7 @@ public:
             "8441436038339044149526344321901146575444541784240209246165157233507787077498171257724679629263863563732899121548"
             "31438167899885040445364023527381951378636564391212010397122822120720357";
         nMaxZerocoinSpendsPerTransaction = 7; // Assume about 20kb each
+        nMaxZerocoinPublicSpendsPerTransaction = 500; // Assume about 220 bytes each input
         nMinZerocoinMintFee = 1 * CENT; // high fee required for zerocoin mints
         nMintRequiredConfirmations = 20; // the maximum amount of confirmations until accumulated in 19
         nRequiredAccumulation = 1;
@@ -271,6 +275,9 @@ public:
         nBlockZerocoinV2 = 2181;			/* First mint at block 312 */
         nEnforceNewSporkKey = 1553907600;		/* Sat Mar 30 01:00:00 UTC 2019: sporks signed after must use the new spork key */
         nRejectOldSporkKey = 1554080400;		/* Mon Apr  1 01:00:00 UTC 2019: after that reject old spork key */
+
+        // Public coin spend enforcement
+        nPublicZCSpends = 232000;
 
         /* Testnet genesis block. */
         genesis.nTime = 1540587600;			/* Testnet started: Fri Oct 26 21:00:00 UTC 2018 */
@@ -359,6 +366,9 @@ public:
         nBlockZerocoinV2 = 300;
         nZerocoinStartTime = 1540587600;
         nBlockEnforceSerialRange = 300; //Enforce serial range starting this block
+
+        // Public coin spend enforcement
+        nPublicZCSpends = 350;
 
         // Modify the regtest genesis block so the timestamp is valid for a later start.
         genesis.nTime = 1540587600;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -109,6 +109,7 @@ public:
     std::string Zerocoin_Modulus() const { return zerocoinModulus; }
     libzerocoin::ZerocoinParams* Zerocoin_Params(bool useModulusV1) const;
     int Zerocoin_MaxSpendsPerTransaction() const { return nMaxZerocoinSpendsPerTransaction; }
+    int Zerocoin_MaxPublicSpendsPerTransaction() const { return nMaxZerocoinPublicSpendsPerTransaction; }
     CAmount Zerocoin_MintFee() const { return nMinZerocoinMintFee; }
     int Zerocoin_MintRequiredConfirmations() const { return nMintRequiredConfirmations; }
     int Zerocoin_RequiredAccumulation() const { return nRequiredAccumulation; }
@@ -124,6 +125,7 @@ public:
     int Zerocoin_Block_EnforceSerialRange() const { return nBlockEnforceSerialRange; }
     int Zerocoin_StartTime() const { return nZerocoinStartTime; }
     int Zerocoin_Block_V2_Start() const { return nBlockZerocoinV2; }
+    int Zerocoin_Block_Public_Spend_Enabled() const { return nPublicZCSpends; }
 
     /** Development Budget **/
     int Budget_SuperBlocks() const { return nBudgetSuperBlocks; };
@@ -175,6 +177,7 @@ protected:
     CAmount nRequiredMasternodeCollateral;
     std::string zerocoinModulus;
     int nMaxZerocoinSpendsPerTransaction;
+    int nMaxZerocoinPublicSpendsPerTransaction;
     CAmount nMinZerocoinMintFee;
     int nMintRequiredConfirmations;
     int nRequiredAccumulation;
@@ -189,6 +192,7 @@ protected:
     int nBlockFirstMint;
     int nBlockEnforceSerialRange;
     int nBlockZerocoinV2;
+    int nPublicZCSpends;
 
     int nBudgetSuperBlocks;
 };

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -374,7 +374,8 @@ bool CheckProofOfStake(const CBlock block, uint256& hashProofOfStake, std::uniqu
         uint256 hashBlock;
         CTransaction txPrev;
         if (!GetTransaction(txin.prevout.hash, txPrev, hashBlock, true))
-            return error("CheckProofOfStake() : INFO: read txPrev failed");
+            return error("CheckProofOfStake() : INFO: read txPrev failed, tx id prev: %s, block id %s",
+                         txin.prevout.hash.GetHex(), block.GetHash().GetHex());
 
         //verify signature and script
         if (!VerifyScript(txin.scriptSig, txPrev.vout[txin.prevout.n].scriptPubKey, STANDARD_SCRIPT_VERIFY_FLAGS, TransactionSignatureChecker(&tx, 0)))

--- a/src/libzerocoin/AccumulatorProofOfKnowledge.h
+++ b/src/libzerocoin/AccumulatorProofOfKnowledge.h
@@ -29,6 +29,7 @@ namespace libzerocoin {
  */
 class AccumulatorProofOfKnowledge {
 public:
+    AccumulatorProofOfKnowledge(){};
 	AccumulatorProofOfKnowledge(const AccumulatorAndProofParams* p);
 
 	/** Generates a proof that a commitment to a coin c was accumulated

--- a/src/libzerocoin/CoinSpend.h
+++ b/src/libzerocoin/CoinSpend.h
@@ -43,6 +43,8 @@ class CoinSpend
 {
 public:
 
+    CoinSpend(){};
+
     //! \param paramsV1 - if this is a V1 zerocoin, then use params that existed with initial modulus, ignored otherwise
     //! \param paramsV2 - params that begin when V2 zerocoins begin on the Galilel network
     //! \param strm - a serialized CoinSpend
@@ -124,10 +126,13 @@ public:
 
     static std::vector<unsigned char> ParseSerial(CDataStream& s);
 
-    const uint256 signatureHash() const;
-    bool Verify(const Accumulator& a, bool verifyParams = true) const;
+    virtual const uint256 signatureHash() const;
+    virtual bool Verify(const Accumulator& a, bool verifyParams = true) const;
     bool HasValidSerial(ZerocoinParams* params) const;
     bool HasValidSignature() const;
+    void setTxOutHash(uint256 txOutHash) { this->ptxHash = txOutHash; };
+    void setDenom(libzerocoin::CoinDenomination denom) { this->denomination = denom; }
+
     CBigNum CalculateValidSerial(ZerocoinParams* params);
     std::string ToString() const;
 
@@ -155,22 +160,24 @@ public:
         }
     }
 
-private:
-    CoinDenomination denomination;
-    uint32_t accChecksum;
-    uint256 ptxHash;
-    CBigNum accCommitmentToCoinValue;
-    CBigNum serialCommitmentToCoinValue;
+protected:
+    CoinDenomination denomination = ZQ_ERROR;
     CBigNum coinSerialNumber;
-    AccumulatorProofOfKnowledge accumulatorPoK;
-    SerialNumberSignatureOfKnowledge serialNumberSoK;
-    CommitmentProofOfKnowledge commitmentPoK;
     uint8_t version;
-
     //As of version 2
     CPubKey pubkey;
     std::vector<unsigned char> vchSig;
     SpendType spendType;
+    uint256 ptxHash;
+
+private:
+    uint32_t accChecksum;
+    CBigNum accCommitmentToCoinValue;
+    CBigNum serialCommitmentToCoinValue;
+    AccumulatorProofOfKnowledge accumulatorPoK;
+    SerialNumberSignatureOfKnowledge serialNumberSoK;
+    CommitmentProofOfKnowledge commitmentPoK;
+
 };
 
 } /* namespace libzerocoin */

--- a/src/libzerocoin/Commitment.h
+++ b/src/libzerocoin/Commitment.h
@@ -65,6 +65,7 @@ private:
  */
 class CommitmentProofOfKnowledge {
 public:
+    CommitmentProofOfKnowledge(){};
 	CommitmentProofOfKnowledge(const IntegerGroupParams* ap, const IntegerGroupParams* bp);
 	/** Generates a proof that two commitments, a and b, open to the same value.
 	 *

--- a/src/libzerocoin/SerialNumberSignatureOfKnowledge.h
+++ b/src/libzerocoin/SerialNumberSignatureOfKnowledge.h
@@ -39,6 +39,7 @@ namespace libzerocoin {
  */
 class SerialNumberSignatureOfKnowledge {
 public:
+    SerialNumberSignatureOfKnowledge(){};
 	SerialNumberSignatureOfKnowledge(const ZerocoinParams* p);
 	/** Creates a Signature of knowledge object that a commitment to a coin contains a coin with serial number x
 	 *

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -741,7 +741,7 @@ bool IsStandardTx(const CTransaction& tx, string& reason)
     }
 
     for (const CTxIn& txin : tx.vin) {
-        if (txin.IsZerocoinSpend())
+        if (txin.IsZerocoinSpend() || txin.IsZerocoinPublicSpend())
             continue;
         // Biggest 'standard' txin is a 15-of-15 P2SH multisig with compressed
         // keys. (remember the 520 byte limit on redeemScript size) That works
@@ -982,7 +982,22 @@ bool ContextualCheckZerocoinMint(const CTransaction& tx, const PublicCoin& coin,
     return true;
 }
 
-bool ContextualCheckZerocoinSpend(const CTransaction& tx, const CoinSpend& spend, CBlockIndex* pindex, const uint256& hashBlock)
+bool CheckPublicCoinSpendEnforced(int blockHeight, bool isPublicSpend) {
+    if (blockHeight >= Params().Zerocoin_Block_Public_Spend_Enabled()) {
+        // reject old coin spend
+        if (!isPublicSpend) {
+            return error("%s: failed to add block with older zc spend version", __func__);
+        }
+
+    } else {
+        if (isPublicSpend) {
+            return error("%s: failed to add block, public spend enforcement not activated", __func__);
+        }
+    }
+    return true;
+}
+
+bool ContextualCheckZerocoinSpend(const CTransaction& tx, const CoinSpend* spend, CBlockIndex* pindex, const uint256& hashBlock)
 {
     if(!ContextualCheckZerocoinSpendNoSerialCheck(tx, spend, pindex, hashBlock)){
         return false;
@@ -990,35 +1005,43 @@ bool ContextualCheckZerocoinSpend(const CTransaction& tx, const CoinSpend& spend
 
     //Reject serial's that are already in the blockchain
     int nHeightTx = 0;
-    if (IsSerialInBlockchain(spend.getCoinSerialNumber(), nHeightTx))
+    if (IsSerialInBlockchain(spend->getCoinSerialNumber(), nHeightTx))
         return error("%s : zGALI spend with serial %s is already in block %d\n", __func__,
-                     spend.getCoinSerialNumber().GetHex(), nHeightTx);
+                     spend->getCoinSerialNumber().GetHex(), nHeightTx);
 
     return true;
 }
 
-bool ContextualCheckZerocoinSpendNoSerialCheck(const CTransaction& tx, const CoinSpend& spend, CBlockIndex* pindex, const uint256& hashBlock)
+bool ContextualCheckZerocoinSpendNoSerialCheck(const CTransaction& tx, const CoinSpend* spend, CBlockIndex* pindex, const uint256& hashBlock)
 {
     //Check to see if the zGALI is properly signed
     if (pindex->nHeight >= Params().Zerocoin_Block_V2_Start()) {
-        if (!spend.HasValidSignature())
+        if (!spend->HasValidSignature())
             return error("%s: V2 zGALI spend does not have a valid signature", __func__);
 
         libzerocoin::SpendType expectedType = libzerocoin::SpendType::SPEND;
         if (tx.IsCoinStake())
             expectedType = libzerocoin::SpendType::STAKE;
-        if (spend.getSpendType() != expectedType) {
+        if (spend->getSpendType() != expectedType) {
             return error("%s: trying to spend zGALI without the correct spend type. txid=%s\n", __func__,
                          tx.GetHash().GetHex());
         }
     }
 
+    bool v1Serial = spend->getVersion() < libzerocoin::PrivateCoin::PUBKEY_VERSION;
+    if (pindex->nHeight >= Params().Zerocoin_Block_Public_Spend_Enabled()) {
+        //Reject V1 old serials.
+        if (v1Serial) {
+            return error("%s : zGALI v1 serial spend not spendable, serial %s, tx %s\n", __func__,
+                         spend->getCoinSerialNumber().GetHex(), tx.GetHash().GetHex());
+        }
+    }
+
     //Reject serial's that are not in the acceptable value range
-    bool fUseV1Params = spend.getVersion() < libzerocoin::PrivateCoin::PUBKEY_VERSION;
-    if (pindex->nHeight > Params().Zerocoin_Block_EnforceSerialRange() &&
-        !spend.HasValidSerial(Params().Zerocoin_Params(fUseV1Params)))
+    if (!spend->HasValidSerial(Params().Zerocoin_Params(v1Serial))) {
         return error("%s : zGALI spend with serial %s from tx %s is not in valid range\n", __func__,
-                     spend.getCoinSerialNumber().GetHex(), tx.GetHash().GetHex());
+                     spend->getCoinSerialNumber().GetHex(), tx.GetHash().GetHex());
+    }
 
     return true;
 }
@@ -1047,16 +1070,29 @@ bool CheckZerocoinSpend(const CTransaction& tx, bool fVerifySignature, CValidati
 
     bool fValidated = false;
     set<CBigNum> serials;
-    list<CoinSpend> vSpends;
     CAmount nTotalRedeemed = 0;
     for (const CTxIn& txin : tx.vin) {
 
         //only check txin that is a zcspend
-        if (!txin.IsZerocoinSpend())
+        bool isPublicSpend = txin.IsZerocoinPublicSpend();
+        if (!txin.IsZerocoinSpend() && !isPublicSpend)
             continue;
 
-        CoinSpend newSpend = TxInToZerocoinSpend(txin);
-        vSpends.push_back(newSpend);
+        CoinSpend newSpend;
+        CTxOut prevOut;
+        if (isPublicSpend) {
+            if(!GetOutput(txin.prevout.hash, txin.prevout.n, state, prevOut)){
+                return state.DoS(100, error("CheckZerocoinSpend(): public zerocoin spend prev output not found, prevTx %s, index %d", txin.prevout.hash.GetHex(), txin.prevout.n));
+            }
+            libzerocoin::ZerocoinParams* params = Params().Zerocoin_Params(false);
+            PublicCoinSpend publicSpend(params);
+            if (!ZGALIModule::parseCoinSpend(txin, tx, prevOut, publicSpend)){
+                return state.DoS(100, error("CheckZerocoinSpend(): public zerocoin spend parse failed"));
+            }
+            newSpend = publicSpend;
+        }else {
+            newSpend = TxInToZerocoinSpend(txin);
+        }
 
         //check that the denomination is valid
         if (newSpend.getDenomination() == ZQ_ERROR)
@@ -1083,21 +1119,29 @@ bool CheckZerocoinSpend(const CTransaction& tx, bool fVerifySignature, CValidati
         }
 
         // Skip signature verification during initial block download and for broken checksum range
-        if (fVerifySignature) {
-            //see if we have record of the accumulator used in the spend tx
-            CBigNum bnAccumulatorValue = 0;
-            if (!zerocoinDB->ReadAccumulatorValue(newSpend.getAccumulatorChecksum(), bnAccumulatorValue)) {
-                uint32_t nChecksum = newSpend.getAccumulatorChecksum();
-                return state.DoS(100, error("%s: Zerocoinspend could not find accumulator associated with checksum %s", __func__, HexStr(BEGIN(nChecksum), END(nChecksum))));
+        if (isPublicSpend) {
+            libzerocoin::ZerocoinParams* params = Params().Zerocoin_Params(false);
+            PublicCoinSpend ret(params);
+            if (!ZGALIModule::validateInput(txin, prevOut, tx, ret)){
+                return state.DoS(100, error("CheckZerocoinSpend(): public zerocoin spend did not verify"));
             }
+        } else
+            // Skip signature verification during initial block download
+            if (fVerifySignature) {
+                //see if we have record of the accumulator used in the spend tx
+                CBigNum bnAccumulatorValue = 0;
+                if (!zerocoinDB->ReadAccumulatorValue(newSpend.getAccumulatorChecksum(), bnAccumulatorValue)) {
+                    uint32_t nChecksum = newSpend.getAccumulatorChecksum();
+                    return state.DoS(100, error("%s: Zerocoinspend could not find accumulator associated with checksum %s", __func__, HexStr(BEGIN(nChecksum), END(nChecksum))));
+                }
 
-            Accumulator accumulator(Params().Zerocoin_Params(chainActive.Height() < Params().Zerocoin_Block_V2_Start()),
-                                    newSpend.getDenomination(), bnAccumulatorValue);
+                Accumulator accumulator(Params().Zerocoin_Params(chainActive.Height() < Params().Zerocoin_Block_V2_Start()),
+                                        newSpend.getDenomination(), bnAccumulatorValue);
 
-            //Check that the coin has been accumulated
-            if(!newSpend.Verify(accumulator))
-                    return state.DoS(100, error("CheckZerocoinSpend(): zerocoin spend did not verify"));
-        }
+                //Check that the coin has been accumulated
+                if(!newSpend.Verify(accumulator))
+                        return state.DoS(100, error("CheckZerocoinSpend(): zerocoin spend did not verify"));
+            }
 
         if (serials.count(newSpend.getCoinSerialNumber()))
             return state.DoS(100, error("Zerocoinspend serial is used twice in the same tx"));
@@ -1167,7 +1211,7 @@ bool CheckTransaction(const CTransaction& tx, bool fZerocoinActive, bool fReject
         //duplicate zcspend serials are checked in CheckZerocoinSpend()
         if (!txin.IsZerocoinSpend()) {
             vInOutPoints.insert(txin.prevout);
-        } else {
+        } else if (!txin.IsZerocoinPublicSpend()) {
             nZCSpendCount++;
         }
     }
@@ -1179,8 +1223,9 @@ bool CheckTransaction(const CTransaction& tx, bool fZerocoinActive, bool fReject
         //require that a zerocoinspend only has inputs that are zerocoins
         if (tx.HasZerocoinSpendInputs()) {
             for (const CTxIn& in : tx.vin) {
-                if (!in.IsZerocoinSpend())
-                    return state.DoS(100, error("CheckTransaction() : zerocoinspend contains inputs that are not zerocoins"));
+                if (!in.IsZerocoinSpend() && !in.IsZerocoinPublicSpend())
+                    return state.DoS(100,
+                                     error("CheckTransaction() : zerocoinspend contains inputs that are not zerocoins"));
             }
 
             // Do not require signature verification if this is initial sync and a block over 24 hours old
@@ -1195,8 +1240,18 @@ bool CheckTransaction(const CTransaction& tx, bool fZerocoinActive, bool fReject
             return state.DoS(100, error("CheckTransaction() : coinbase script size=%d", tx.vin[0].scriptSig.size()),
                 REJECT_INVALID, "bad-cb-length");
     } else if (fZerocoinActive && tx.HasZerocoinSpendInputs()) {
-        if(tx.vin.size() < 1 || static_cast<int>(tx.vin.size()) > Params().Zerocoin_MaxSpendsPerTransaction())
-            return state.DoS(10, error("CheckTransaction() : Zerocoin Spend has more than allowed txin's"), REJECT_INVALID, "bad-zerocoinspend");
+        if (tx.vin.size() < 1)
+            return state.DoS(10, error("CheckTransaction() : Zerocoin Spend has less than allowed txin's"), REJECT_INVALID, "bad-zerocoinspend");
+        if (tx.HasZerocoinPublicSpendInputs()) {
+            // tx has public zerocoin spend inputs
+            if(static_cast<int>(tx.vin.size()) > Params().Zerocoin_MaxPublicSpendsPerTransaction())
+                return state.DoS(10, error("CheckTransaction() : Zerocoin Spend has more than allowed txin's"), REJECT_INVALID, "bad-zerocoinspend");
+        } else {
+            // tx has regular zerocoin spend inputs
+            if(static_cast<int>(tx.vin.size()) > Params().Zerocoin_MaxSpendsPerTransaction())
+                return state.DoS(10, error("CheckTransaction() : Zerocoin Spend has more than allowed txin's"), REJECT_INVALID, "bad-zerocoinspend");
+        }
+
     } else {
         for (const CTxIn& txin : tx.vin)
             if (txin.prevout.IsNull() && (fZerocoinActive && !txin.IsZerocoinSpend()))
@@ -1349,12 +1404,36 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState& state, const CTransa
 
             //Check for double spending of serial #'s
             for (const CTxIn& txIn : tx.vin) {
-                if (!txIn.IsZerocoinSpend())
-                    continue;
-                CoinSpend spend = TxInToZerocoinSpend(txIn);
-                if (!ContextualCheckZerocoinSpend(tx, spend, chainActive.Tip(), 0))
-                    return state.Invalid(error("%s: ContextualCheckZerocoinSpend failed for tx %s", __func__,
+                // Only allow for zc spends inputs
+                bool isPublicSpend = txIn.IsZerocoinPublicSpend();
+                bool isPrivZerocoinSpend = txIn.IsZerocoinSpend();
+                if (!isPrivZerocoinSpend && !isPublicSpend) {
+                    return state.Invalid(error("%s: AcceptToMemoryPool failed for tx %s, every input must be a zcspend or zcpublicspend", __func__,
+                                        tx.GetHash().GetHex()), REJECT_INVALID, "bad-txns-invalid-zgali");
+                }
+
+                // Check enforcement
+                if (!CheckPublicCoinSpendEnforced(chainActive.Height(), isPublicSpend)){
+                    return state.Invalid(error("%s: AcceptToMemoryPool failed for tx %s", __func__,
                                                tx.GetHash().GetHex()), REJECT_INVALID, "bad-txns-invalid-zgali");
+                }
+
+                if (isPublicSpend) {
+                    libzerocoin::ZerocoinParams* params = Params().Zerocoin_Params(false);
+                    PublicCoinSpend publicSpend(params);
+                    if (!ZGALIModule::ParseZerocoinPublicSpend(txIn, tx, state, publicSpend)){
+                        return false;
+                    }
+                    if (!ContextualCheckZerocoinSpend(tx, &publicSpend, chainActive.Tip(), 0))
+                        return state.Invalid(error("%s: ContextualCheckZerocoinSpend failed for tx %s", __func__,
+                                                   tx.GetHash().GetHex()), REJECT_INVALID, "bad-txns-invalid-zgali");
+                } else {
+                    CoinSpend spend = TxInToZerocoinSpend(txIn);
+                    if (!ContextualCheckZerocoinSpend(tx, &spend, chainActive.Tip(), 0))
+                        return state.Invalid(error("%s: ContextualCheckZerocoinSpend failed for tx %s", __func__,
+                                                   tx.GetHash().GetHex()), REJECT_INVALID, "bad-txns-invalid-zgali");
+                }
+
             }
         } else {
             LOCK(pool.cs);
@@ -1392,7 +1471,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState& state, const CTransa
             // are the actual inputs available?
             if (!view.HaveInputs(tx))
                 return state.Invalid(error("AcceptToMemoryPool : inputs already spent"),
-                    REJECT_DUPLICATE, "bad-txns-inputs-spent");
+                                     REJECT_DUPLICATE, "bad-txns-inputs-spent");
 
             // Bring the best block into scope
             view.GetBestBlock();
@@ -1701,6 +1780,20 @@ bool AcceptableInputs(CTxMemPool& pool, CValidationState& state, const CTransact
 
     // SyncWithWallets(tx, NULL);
 
+    return true;
+}
+
+bool GetOutput(const uint256& hash, unsigned int index, CValidationState& state, CTxOut& out)
+{
+    CTransaction txPrev;
+    uint256 hashBlock;
+    if (!GetTransaction(hash, txPrev, hashBlock, true)) {
+        return state.DoS(100, error("Output not found"));
+    }
+    if (index > txPrev.vout.size()) {
+        return state.DoS(100, error("Output not found, invalid index %d for %s",index, hash.GetHex()));
+    }
+    out = txPrev.vout[index];
     return true;
 }
 
@@ -2220,38 +2313,54 @@ bool DisconnectBlock(CBlock& block, CValidationState& state, CBlockIndex* pindex
          * note we only undo zerocoin databasing in the following statement, value to and from GALI
          * addresses should still be handled by the typical bitcoin based undo code
          * */
-        if (tx.HasZerocoinSpendInputs()) {
-            //erase all zerocoinspends in this transaction
-            for (const CTxIn& txin : tx.vin) {
-                if (txin.IsZerocoinSpend()) {
-                    CoinSpend spend = TxInToZerocoinSpend(txin);
-                    if (!zerocoinDB->EraseCoinSpend(spend.getCoinSerialNumber()))
-                        return error("failed to erase spent zerocoin in block");
+        if (tx.ContainsZerocoins()) {
+            if (tx.HasZerocoinSpendInputs()) {
+                //erase all zerocoinspends in this transaction
+                for (const CTxIn &txin : tx.vin) {
+                    bool isPublicSpend = txin.IsZerocoinPublicSpend();
+                    if (txin.scriptSig.IsZerocoinSpend() || isPublicSpend) {
+                        CBigNum serial;
+                        if (isPublicSpend) {
+                            libzerocoin::ZerocoinParams *params = Params().Zerocoin_Params(false);
+                            PublicCoinSpend publicSpend(params);
+                            CValidationState state;
+                            if (!ZGALIModule::ParseZerocoinPublicSpend(txin, tx, state, publicSpend)) {
+                                return error("Failed to parse public spend");
+                            }
+                            serial = publicSpend.getCoinSerialNumber();
+                        } else {
+                            CoinSpend spend = TxInToZerocoinSpend(txin);
+                            serial = spend.getCoinSerialNumber();
+                        }
 
-                    //if this was our spend, then mark it unspent now
-                    if (pwalletMain) {
-                        if (pwalletMain->IsMyZerocoinSpend(spend.getCoinSerialNumber())) {
-                            if (!pwalletMain->SetMintUnspent(spend.getCoinSerialNumber()))
-                                LogPrintf("%s: failed to automatically reset mint", __func__);
+                        if (!zerocoinDB->EraseCoinSpend(serial))
+                            return error("failed to erase spent zerocoin in block");
+
+                        //if this was our spend, then mark it unspent now
+                        if (pwalletMain) {
+                            if (pwalletMain->IsMyZerocoinSpend(serial)) {
+                                if (!pwalletMain->SetMintUnspent(serial))
+                                    LogPrintf("%s: failed to automatically reset mint", __func__);
+                            }
                         }
                     }
+
                 }
-
             }
-        }
 
-        if (tx.HasZerocoinMintOutputs()) {
-            //erase all zerocoinmints in this transaction
-            for (const CTxOut& txout : tx.vout) {
-                if (txout.scriptPubKey.empty() || !txout.IsZerocoinMint())
-                    continue;
+            if (tx.HasZerocoinMintOutputs()) {
+                //erase all zerocoinmints in this transaction
+                for (const CTxOut &txout : tx.vout) {
+                    if (txout.scriptPubKey.empty() || !txout.IsZerocoinMint())
+                        continue;
 
-                PublicCoin pubCoin(Params().Zerocoin_Params(false));
-                if (!TxOutToPublicCoin(txout, pubCoin, state))
-                    return error("DisconnectBlock(): TxOutToPublicCoin() failed");
+                    PublicCoin pubCoin(Params().Zerocoin_Params(false));
+                    if (!TxOutToPublicCoin(txout, pubCoin, state))
+                        return error("DisconnectBlock(): TxOutToPublicCoin() failed");
 
-                if(!zerocoinDB->EraseCoinMint(pubCoin.getValue()))
-                    return error("DisconnectBlock(): Failed to erase coin mint");
+                    if (!zerocoinDB->EraseCoinMint(pubCoin.getValue()))
+                        return error("DisconnectBlock(): Failed to erase coin mint");
+                }
             }
         }
 
@@ -2715,15 +2824,35 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
             //Check for double spending of serial #'s
             set<CBigNum> setSerials;
             for (const CTxIn& txIn : tx.vin) {
-                if (!txIn.IsZerocoinSpend())
+                bool isPublicSpend = txIn.IsZerocoinPublicSpend();
+                bool isPrivZerocoinSpend = txIn.IsZerocoinSpend();
+                if (!isPrivZerocoinSpend && !isPublicSpend)
                     continue;
-                CoinSpend spend = TxInToZerocoinSpend(txIn);
-                nValueIn += spend.getDenomination() * COIN;
 
-                //queue for db write after the 'justcheck' section has concluded
-                vSpends.emplace_back(make_pair(spend, tx.GetHash()));
-                if (!ContextualCheckZerocoinSpend(tx, spend, pindex, hashBlock))
-                    return state.DoS(100, error("%s: failed to add block %s with invalid zerocoinspend", __func__, tx.GetHash().GetHex()), REJECT_INVALID);
+                // Check enforcement
+                if (!CheckPublicCoinSpendEnforced(pindex->nHeight, isPublicSpend)){
+                    return false;
+                }
+
+                if (isPublicSpend) {
+                    libzerocoin::ZerocoinParams* params = Params().Zerocoin_Params(false);
+                    PublicCoinSpend publicSpend(params);
+                    if (!ZGALIModule::ParseZerocoinPublicSpend(txIn, tx, state, publicSpend)){
+                        return false;
+                    }
+                    nValueIn += publicSpend.getDenomination() * COIN;
+                    //queue for db write after the 'justcheck' section has concluded
+                    vSpends.emplace_back(make_pair(publicSpend, tx.GetHash()));
+                    if (!ContextualCheckZerocoinSpend(tx, &publicSpend, pindex, hashBlock))
+                        return state.DoS(100, error("%s: failed to add block %s with invalid public zc spend", __func__, tx.GetHash().GetHex()), REJECT_INVALID);
+                } else {
+                    CoinSpend spend = TxInToZerocoinSpend(txIn);
+                    nValueIn += spend.getDenomination() * COIN;
+                    //queue for db write after the 'justcheck' section has concluded
+                    vSpends.emplace_back(make_pair(spend, tx.GetHash()));
+                    if (!ContextualCheckZerocoinSpend(tx, &spend, pindex, hashBlock))
+                        return state.DoS(100, error("%s: failed to add block %s with invalid zerocoinspend", __func__, tx.GetHash().GetHex()), REJECT_INVALID);
+                }
             }
 
             // Check that zGALI mints are not already known
@@ -3868,8 +3997,19 @@ bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW, bo
         // double check that there are no double spent zGALI spends in this block
         if (tx.HasZerocoinSpendInputs()) {
             for (const CTxIn& txIn : tx.vin) {
-                if (txIn.IsZerocoinSpend()) {
-                    libzerocoin::CoinSpend spend = TxInToZerocoinSpend(txIn);
+                bool isPublicSpend = txIn.IsZerocoinPublicSpend();
+                if (txIn.IsZerocoinSpend() || isPublicSpend) {
+                    libzerocoin::CoinSpend spend;
+                    if (isPublicSpend) {
+                        libzerocoin::ZerocoinParams* params = Params().Zerocoin_Params(false);
+                        PublicCoinSpend publicSpend(params);
+                        if (!ZGALIModule::ParseZerocoinPublicSpend(txIn, tx, state, publicSpend)){
+                            return false;
+                        }
+                        spend = publicSpend;
+                    } else {
+                        spend = TxInToZerocoinSpend(txIn);
+                    }
                     if (count(vBlockSerials.begin(), vBlockSerials.end(), spend.getCoinSerialNumber()))
                         return state.DoS(100, error("%s : Double spending of zGALI serial %s in block\n Block: %s",
                                                     __func__, spend.getCoinSerialNumber().GetHex(), block.ToString()));
@@ -4208,8 +4348,26 @@ bool AcceptBlock(CBlock& block, CValidationState& state, CBlockIndex** ppindex, 
         for (const CTransaction& tx : block.vtx) {
             for (const CTxIn& in: tx.vin) {
                 if(nHeight >= Params().Zerocoin_Block_V2_Start()) {
-                    if (in.IsZerocoinSpend()) {
-                        CoinSpend spend = TxInToZerocoinSpend(in);
+                    bool isPublicSpend = in.scriptSig.IsZerocoinPublicSpend();
+                    bool isPrivZerocoinSpend = in.IsZerocoinSpend();
+                    if (isPrivZerocoinSpend || isPublicSpend) {
+
+                        // Check enforcement
+                        if (!CheckPublicCoinSpendEnforced(pindex->nHeight, isPublicSpend)){
+                            return false;
+                        }
+
+                        libzerocoin::CoinSpend spend;
+                        if (isPublicSpend) {
+                            libzerocoin::ZerocoinParams* params = Params().Zerocoin_Params(false);
+                            PublicCoinSpend publicSpend(params);
+                            if (!ZGALIModule::ParseZerocoinPublicSpend(in, tx, state, publicSpend)){
+                                return false;
+                            }
+                            spend = publicSpend;
+                        } else {
+                            spend = TxInToZerocoinSpend(in);
+                        }
                         // Check for serials double spending in the same block
                         if (std::find(inBlockSerials.begin(), inBlockSerials.end(), spend.getCoinSerialNumber()) !=
                             inBlockSerials.end()) {
@@ -4315,7 +4473,7 @@ bool AcceptBlock(CBlock& block, CValidationState& state, CBlockIndex** ppindex, 
                         }
                     }
 
-                    if (!ContextualCheckZerocoinSpendNoSerialCheck(stakeTxIn, spend, pindex, 0))
+                    if (!ContextualCheckZerocoinSpendNoSerialCheck(stakeTxIn, &spend, pindex, 0))
                         return state.DoS(100,error("%s: forked chain ContextualCheckZerocoinSpend failed for tx %s", __func__,
                                                    stakeTxIn.GetHash().GetHex()), REJECT_INVALID, "bad-txns-invalid-zgali");
 
@@ -4360,7 +4518,7 @@ bool AcceptBlock(CBlock& block, CValidationState& state, CBlockIndex** ppindex, 
             if(!isBlockFromFork)
                 for (const CTxIn& zGaliInput : zGALIInputs) {
                         CoinSpend spend = TxInToZerocoinSpend(zGaliInput);
-                        if (!ContextualCheckZerocoinSpend(stakeTxIn, spend, pindex, 0))
+                        if (!ContextualCheckZerocoinSpend(stakeTxIn, &spend, pindex, 0))
                             return state.DoS(100,error("%s: main chain ContextualCheckZerocoinSpend failed for tx %s", __func__,
                                     stakeTxIn.GetHash().GetHex()), REJECT_INVALID, "bad-txns-invalid-zgali");
                 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -969,7 +969,12 @@ bool CheckZerocoinMint(const uint256& txHash, const CTxOut& txout, CValidationSt
 
 bool ContextualCheckZerocoinMint(const CTransaction& tx, const PublicCoin& coin, const CBlockIndex* pindex)
 {
-    if (pindex->nHeight >= Params().Zerocoin_Block_V2_Start()) {
+    if (pindex->nHeight >= Params().Zerocoin_Block_Public_Spend_Enabled()) {
+        // Zerocoin MINTs have been disabled
+        return error("%s: Mints disabled at height %d - unable to add pubcoin %s", __func__,
+                pindex->nHeight, coin.getValue().GetHex().substr(0, 10));
+    }
+    if (pindex->nHeight >= Params().Zerocoin_Block_V2_Start() && Params().NetworkID() != CBaseChainParams::TESTNET) {
         //See if this coin has already been added to the blockchain
         uint256 txid;
         int nHeight;
@@ -3130,11 +3135,15 @@ void static UpdateTip(CBlockIndex* pindexNew)
 {
     chainActive.SetTip(pindexNew);
 
+    /* Zerocoin minting is disabled
+     *
 #ifdef ENABLE_WALLET
     // If turned on AutoZeromint will automatically convert GALI to zGALI
     if (pwalletMain && pwalletMain->isZeromintEnabled())
         pwalletMain->AutoZeromint();
 #endif // ENABLE_WALLET
+    *
+    */
 
     // New best block
     nTimeBestReceived = GetTime();

--- a/src/main.h
+++ b/src/main.h
@@ -23,6 +23,7 @@
 #include "primitives/block.h"
 #include "primitives/transaction.h"
 #include "zgali/zerocoin.h"
+#include "zgali/zgalimodule.h"
 #include "script/script.h"
 #include "script/sigcache.h"
 #include "script/standard.h"
@@ -239,6 +240,8 @@ bool IsInitialBlockDownload();
 std::string GetWarnings(std::string strFor);
 /** Retrieve a transaction (from memory pool, or from disk, if possible) */
 bool GetTransaction(const uint256& hash, CTransaction& tx, uint256& hashBlock, bool fAllowSlow = false, CBlockIndex* blockIndex = nullptr);
+/** Retrieve an output (from memory pool, or from disk, if possible) */
+bool GetOutput(const uint256& hash, unsigned int index, CValidationState& state, CTxOut& out);
 /** Find the best known block, and make it the tip of the block chain */
 
 // ***TODO***
@@ -359,8 +362,8 @@ void UpdateCoins(const CTransaction& tx, CValidationState& state, CCoinsViewCach
 bool CheckTransaction(const CTransaction& tx, bool fZerocoinActive, bool fRejectBadUTXO, CValidationState& state);
 bool CheckZerocoinMint(const uint256& txHash, const CTxOut& txout, CValidationState& state, bool fCheckOnly = false);
 bool CheckZerocoinSpend(const CTransaction& tx, bool fVerifySignature, CValidationState& state);
-bool ContextualCheckZerocoinSpend(const CTransaction& tx, const libzerocoin::CoinSpend& spend, CBlockIndex* pindex, const uint256& hashBlock);
-bool ContextualCheckZerocoinSpendNoSerialCheck(const CTransaction& tx, const libzerocoin::CoinSpend& spend, CBlockIndex* pindex, const uint256& hashBlock);
+bool ContextualCheckZerocoinSpend(const CTransaction& tx, const libzerocoin::CoinSpend* spend, CBlockIndex* pindex, const uint256& hashBlock);
+bool ContextualCheckZerocoinSpendNoSerialCheck(const CTransaction& tx, const libzerocoin::CoinSpend* spend, CBlockIndex* pindex, const uint256& hashBlock);
 bool IsTransactionInChain(const uint256& txId, int& nHeightTx, CTransaction& tx);
 bool IsTransactionInChain(const uint256& txId, int& nHeightTx);
 bool IsBlockHashInChain(const uint256& hashBlock);
@@ -369,6 +372,8 @@ void RecalculateZGALIMinted();
 bool RecalculateGALISupply(int nHeightStart);
 bool ReindexAccumulators(list<uint256>& listMissingCheckpoints, string& strError);
 
+// Public coin spend
+bool CheckPublicCoinSpendEnforced(int blockHeight, bool isPublicSpend);
 
 /**
  * Check if transaction will be final in the next block to be created.

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -362,18 +362,32 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn, CWallet* pwallet, 
 
                 bool fDoubleSerial = false;
                 for (const CTxIn& txIn : tx.vin) {
-                    if (txIn.IsZerocoinSpend()) {
-                        libzerocoin::CoinSpend spend = TxInToZerocoinSpend(txIn);
-                        bool fUseV1Params = libzerocoin::ExtractVersionFromSerial(spend.getCoinSerialNumber()) < libzerocoin::PrivateCoin::PUBKEY_VERSION;
-                        if (!spend.HasValidSerial(Params().Zerocoin_Params(fUseV1Params)))
+                    bool isPublicSpend = txIn.IsZerocoinPublicSpend();
+                    if (txIn.IsZerocoinSpend() || isPublicSpend) {
+                        libzerocoin::CoinSpend* spend;
+                        if (isPublicSpend) {
+                            libzerocoin::ZerocoinParams* params = Params().Zerocoin_Params(false);
+                            PublicCoinSpend publicSpend(params);
+                            CValidationState state;
+                            if (!ZGALIModule::ParseZerocoinPublicSpend(txIn, tx, state, publicSpend)){
+                                throw std::runtime_error("Invalid public spend parse");
+                            }
+                            spend = &publicSpend;
+                        } else {
+                            libzerocoin::CoinSpend spendObj = TxInToZerocoinSpend(txIn);
+                            spend = &spendObj;
+                        }
+
+                        bool fUseV1Params = libzerocoin::ExtractVersionFromSerial(spend->getCoinSerialNumber()) < libzerocoin::PrivateCoin::PUBKEY_VERSION;
+                        if (!spend->HasValidSerial(Params().Zerocoin_Params(fUseV1Params)))
                             fDoubleSerial = true;
-                        if (count(vBlockSerials.begin(), vBlockSerials.end(), spend.getCoinSerialNumber()))
+                        if (count(vBlockSerials.begin(), vBlockSerials.end(), spend->getCoinSerialNumber()))
                             fDoubleSerial = true;
-                        if (count(vTxSerials.begin(), vTxSerials.end(), spend.getCoinSerialNumber()))
+                        if (count(vTxSerials.begin(), vTxSerials.end(), spend->getCoinSerialNumber()))
                             fDoubleSerial = true;
                         if (fDoubleSerial)
                             break;
-                        vTxSerials.emplace_back(spend.getCoinSerialNumber());
+                        vTxSerials.emplace_back(spend->getCoinSerialNumber());
                     }
                 }
                 //This zGALI serial has already been included in the block, do not add this tx.

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -67,6 +67,11 @@ bool CTxIn::IsZerocoinSpend() const
     return prevout.hash == 0 && scriptSig.IsZerocoinSpend();
 }
 
+bool CTxIn::IsZerocoinPublicSpend() const
+{
+    return scriptSig.IsZerocoinPublicSpend();
+}
+
 std::string CTxIn::ToString() const
 {
     std::string str;
@@ -169,7 +174,7 @@ CTransaction& CTransaction::operator=(const CTransaction &tx) {
 bool CTransaction::HasZerocoinSpendInputs() const
 {
     for (const CTxIn& txin: vin) {
-        if (txin.IsZerocoinSpend())
+        if (txin.IsZerocoinSpend() || txin.IsZerocoinPublicSpend())
             return true;
     }
     return false;
@@ -179,6 +184,16 @@ bool CTransaction::HasZerocoinMintOutputs() const
 {
     for(const CTxOut& txout : vout) {
         if (txout.IsZerocoinMint())
+            return true;
+    }
+    return false;
+}
+
+bool CTransaction::HasZerocoinPublicSpendInputs() const
+{
+    // The wallet only allows publicSpend inputs in the same tx and not a combination between gali and zgali
+    for(const CTxIn& txin : vin) {
+        if (txin.IsZerocoinPublicSpend())
             return true;
     }
     return false;

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -99,6 +99,7 @@ public:
     }
 
     bool IsZerocoinSpend() const;
+    bool IsZerocoinPublicSpend() const;
 
     friend bool operator==(const CTxIn& a, const CTxIn& b)
     {
@@ -263,12 +264,13 @@ public:
     unsigned int CalculateModifiedSize(unsigned int nTxSize=0) const;
 
     bool HasZerocoinSpendInputs() const;
+    bool HasZerocoinPublicSpendInputs() const;
 
     bool HasZerocoinMintOutputs() const;
 
     bool ContainsZerocoins() const
     {
-        return HasZerocoinSpendInputs() || HasZerocoinMintOutputs();
+        return HasZerocoinSpendInputs() || HasZerocoinPublicSpendInputs() || HasZerocoinMintOutputs();
     }
 
     CAmount GetZerocoinMinted() const;

--- a/src/qt/forms/privacydialog.ui
+++ b/src/qt/forms/privacydialog.ui
@@ -343,77 +343,6 @@
                       <item>
                        <layout class="QHBoxLayout" name="horizontalLayout_4">
                         <item>
-                         <widget class="QPushButton" name="pushButtonMintzGALI">
-                          <property name="minimumSize">
-                           <size>
-                            <width>131</width>
-                            <height>0</height>
-                           </size>
-                          </property>
-                          <property name="toolTip">
-                           <string>Enter an amount of GALI to convert to zGALI</string>
-                          </property>
-                          <property name="text">
-                           <string>Mint Zerocoin</string>
-                          </property>
-                         </widget>
-                        </item>
-                        <item>
-                         <widget class="QLineEdit" name="labelMintAmountValue">
-                          <property name="minimumSize">
-                           <size>
-                            <width>60</width>
-                            <height>0</height>
-                           </size>
-                          </property>
-                          <property name="text">
-                           <string>0</string>
-                          </property>
-                          <property name="alignment">
-                           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                          </property>
-                         </widget>
-                        </item>
-                        <item>
-                         <widget class="QLabel" name="labelzGALI_2">
-                          <property name="text">
-                           <string>zGALI</string>
-                          </property>
-                         </widget>
-                        </item>
-                        <item>
-                         <widget class="QLabel" name="labelzGALIAmountText">
-                          <property name="toolTip">
-                           <string>Available for minting are coins which are confirmed and not locked or Masternode collaterals.</string>
-                          </property>
-                          <property name="text">
-                           <string>Available for Minting:</string>
-                          </property>
-                          <property name="alignment">
-                           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                          </property>
-                         </widget>
-                        </item>
-                        <item>
-                         <widget class="QLabel" name="labelzGALIAmountValue">
-                          <property name="font">
-                           <font>
-                            <weight>75</weight>
-                            <bold>true</bold>
-                           </font>
-                          </property>
-                          <property name="toolTip">
-                           <string>Enter an amount of GALI to convert to zGALI</string>
-                          </property>
-                          <property name="text">
-                           <string>0.000 000 00 GALI</string>
-                          </property>
-                          <property name="alignment">
-                           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-                          </property>
-                         </widget>
-                        </item>
-                        <item>
                          <spacer name="horizontalSpacer_2">
                           <property name="orientation">
                            <enum>Qt::Horizontal</enum>
@@ -427,169 +356,15 @@
                          </spacer>
                         </item>
                         <item>
-                         <widget class="QPushButton" name="pushButtonSpentReset">
-                          <property name="maximumSize">
-                           <size>
-                            <width>80</width>
-                            <height>16777215</height>
-                           </size>
-                          </property>
-                          <property name="toolTip">
-                           <string>Reset Zerocoin Wallet DB. Deletes transactions that did not make it into the blockchain.</string>
-                          </property>
-                          <property name="text">
-                           <string>Reset</string>
-                          </property>
-                         </widget>
-                        </item>
-                       </layout>
-                      </item>
-                      <item>
-                       <layout class="QHBoxLayout" name="horizontalLayout_5">
-                        <item>
-                         <widget class="QPushButton" name="pushButtonCoinControl">
-                          <property name="minimumSize">
-                           <size>
-                            <width>131</width>
-                            <height>27</height>
-                           </size>
-                          </property>
-                          <property name="maximumSize">
-                           <size>
-                            <width>131</width>
-                            <height>16777215</height>
-                           </size>
-                          </property>
+                         <widget class="QLabel" name="label">
                           <property name="styleSheet">
-                           <string notr="true"/>
+                           <string notr="true">color: red;
+font-weight: bold;</string>
                           </property>
                           <property name="text">
-                           <string>Coin Control...</string>
-                          </property>
-                          <property name="autoDefault">
-                           <bool>false</bool>
+                           <string>zGALI minting is DISABLED</string>
                           </property>
                          </widget>
-                        </item>
-                        <item>
-                         <layout class="QVBoxLayout" name="verticalLayout_4">
-                          <item>
-                           <widget class="QLabel" name="labelCoinControlQuantityText">
-                            <property name="sizePolicy">
-                             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                              <horstretch>0</horstretch>
-                              <verstretch>0</verstretch>
-                             </sizepolicy>
-                            </property>
-                            <property name="minimumSize">
-                             <size>
-                              <width>0</width>
-                              <height>0</height>
-                             </size>
-                            </property>
-                            <property name="maximumSize">
-                             <size>
-                              <width>16777215</width>
-                              <height>16777215</height>
-                             </size>
-                            </property>
-                            <property name="font">
-                             <font>
-                              <weight>75</weight>
-                              <bold>true</bold>
-                             </font>
-                            </property>
-                            <property name="text">
-                             <string>Quantity:</string>
-                            </property>
-                            <property name="alignment">
-                             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-                            </property>
-                            <property name="margin">
-                             <number>0</number>
-                            </property>
-                           </widget>
-                          </item>
-                          <item>
-                           <widget class="QLabel" name="labelCoinControlAmountText">
-                            <property name="enabled">
-                             <bool>true</bool>
-                            </property>
-                            <property name="font">
-                             <font>
-                              <weight>75</weight>
-                              <bold>true</bold>
-                             </font>
-                            </property>
-                            <property name="text">
-                             <string>Amount:</string>
-                            </property>
-                            <property name="margin">
-                             <number>0</number>
-                            </property>
-                           </widget>
-                          </item>
-                         </layout>
-                        </item>
-                        <item>
-                         <layout class="QVBoxLayout" name="verticalLayout_6">
-                          <item>
-                           <widget class="QLabel" name="labelCoinControlQuantity">
-                            <property name="sizePolicy">
-                             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                              <horstretch>0</horstretch>
-                              <verstretch>0</verstretch>
-                             </sizepolicy>
-                            </property>
-                            <property name="minimumSize">
-                             <size>
-                              <width>0</width>
-                              <height>0</height>
-                             </size>
-                            </property>
-                            <property name="maximumSize">
-                             <size>
-                              <width>16777215</width>
-                              <height>16777215</height>
-                             </size>
-                            </property>
-                            <property name="cursor">
-                             <cursorShape>IBeamCursor</cursorShape>
-                            </property>
-                            <property name="contextMenuPolicy">
-                             <enum>Qt::ActionsContextMenu</enum>
-                            </property>
-                            <property name="text">
-                             <string notr="true">0</string>
-                            </property>
-                            <property name="margin">
-                             <number>0</number>
-                            </property>
-                            <property name="textInteractionFlags">
-                             <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-                            </property>
-                           </widget>
-                          </item>
-                          <item>
-                           <widget class="QLabel" name="labelCoinControlAmount">
-                            <property name="enabled">
-                             <bool>true</bool>
-                            </property>
-                            <property name="cursor">
-                             <cursorShape>IBeamCursor</cursorShape>
-                            </property>
-                            <property name="contextMenuPolicy">
-                             <enum>Qt::ActionsContextMenu</enum>
-                            </property>
-                            <property name="text">
-                             <string notr="true">0.00 GALI</string>
-                            </property>
-                            <property name="textInteractionFlags">
-                             <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-                            </property>
-                           </widget>
-                          </item>
-                         </layout>
                         </item>
                         <item>
                          <spacer name="horizontalSpacer_3">
@@ -620,20 +395,23 @@
                           </property>
                          </widget>
                         </item>
+                        <item>
+                         <widget class="QPushButton" name="pushButtonSpentReset">
+                          <property name="maximumSize">
+                           <size>
+                            <width>80</width>
+                            <height>16777215</height>
+                           </size>
+                          </property>
+                          <property name="toolTip">
+                           <string>Reset Zerocoin Wallet DB. Deletes transactions that did not make it into the blockchain.</string>
+                          </property>
+                          <property name="text">
+                           <string>Reset</string>
+                          </property>
+                         </widget>
+                        </item>
                        </layout>
-                      </item>
-                      <item>
-                       <spacer name="horizontalSpacer_18">
-                        <property name="orientation">
-                         <enum>Qt::Horizontal</enum>
-                        </property>
-                        <property name="sizeHint" stdset="0">
-                         <size>
-                          <width>40</width>
-                          <height>20</height>
-                         </size>
-                        </property>
-                       </spacer>
                       </item>
                       <item>
                        <widget class="QPlainTextEdit" name="TEMintStatus">
@@ -692,6 +470,47 @@
                          <enum>Qt::Horizontal</enum>
                         </property>
                        </widget>
+                      </item>
+                      <item>
+                       <layout class="QHBoxLayout" name="horizontalLayout_7">
+                        <item>
+                         <spacer name="horizontalSpacer_18">
+                          <property name="orientation">
+                           <enum>Qt::Horizontal</enum>
+                          </property>
+                          <property name="sizeHint" stdset="0">
+                           <size>
+                            <width>40</width>
+                            <height>20</height>
+                           </size>
+                          </property>
+                         </spacer>
+                        </item>
+                        <item>
+                         <widget class="QLabel" name="label_2">
+                          <property name="styleSheet">
+                           <string notr="true">color: red;
+font-weight: bold;</string>
+                          </property>
+                          <property name="text">
+                           <string>zGALI spending is NOT private (links back to the mint transaction)</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item>
+                         <spacer name="horizontalSpacer_30">
+                          <property name="orientation">
+                           <enum>Qt::Horizontal</enum>
+                          </property>
+                          <property name="sizeHint" stdset="0">
+                           <size>
+                            <width>40</width>
+                            <height>20</height>
+                           </size>
+                          </property>
+                         </spacer>
+                        </item>
+                       </layout>
                       </item>
                       <item>
                        <layout class="QHBoxLayout" name="horizontalLayout_24">

--- a/src/qt/privacydialog.cpp
+++ b/src/qt/privacydialog.cpp
@@ -38,11 +38,11 @@ PrivacyDialog::PrivacyDialog(QWidget* parent) : QDialog(parent, Qt::WindowSystem
 
     // "Spending 999999 zGALI ought to be enough for anybody." - Bill Gates, 2017
     ui->zGALIpayAmount->setValidator( new QDoubleValidator(0.0, 21000000.0, 20, this) );
-    ui->labelMintAmountValue->setValidator( new QIntValidator(0, 999999, this) );
+    //ui->labelMintAmountValue->setValidator( new QIntValidator(0, 999999, this) );     // disable MINT
 
     // Default texts for (mini-) coincontrol
-    ui->labelCoinControlQuantity->setText (tr("Coins automatically selected"));
-    ui->labelCoinControlAmount->setText (tr("Coins automatically selected"));
+    //ui->labelCoinControlQuantity->setText (tr("Coins automatically selected"));       // disable MINT
+    //ui->labelCoinControlAmount->setText (tr("Coins automatically selected"));         // disable MINT
     ui->labelzGALISyncStatus->setText("(" + tr("out of sync") + ")");
 
     // Sunken frame for minting messages
@@ -52,6 +52,7 @@ PrivacyDialog::PrivacyDialog(QWidget* parent) : QDialog(parent, Qt::WindowSystem
     ui->TEMintStatus->setPlainText(tr("Mint Status: Okay"));
 
     // Coin Control signals
+    /*                                                                            [disable MINT and coinControl]
     connect(ui->pushButtonCoinControl, SIGNAL(clicked()), this, SLOT(coinControlButtonClicked()));
 
     // Coin Control: clipboard actions
@@ -61,6 +62,7 @@ PrivacyDialog::PrivacyDialog(QWidget* parent) : QDialog(parent, Qt::WindowSystem
     connect(clipboardAmountAction, SIGNAL(triggered()), this, SLOT(coinControlClipboardAmount()));
     ui->labelCoinControlQuantity->addAction(clipboardQuantityAction);
     ui->labelCoinControlAmount->addAction(clipboardAmountAction);
+    */
 
     // Denomination labels
     ui->labelzDenom1Text->setText(tr("Denom. with value <b>1</b>:"));
@@ -157,7 +159,8 @@ void PrivacyDialog::on_addressBookButton_clicked()
         ui->zGALIpayAmount->setFocus();
     }
 }
-
+/* disable MINT
+ *
 void PrivacyDialog::on_pushButtonMintzGALI_clicked()
 {
     if (!walletModel || !walletModel->getOptionsModel())
@@ -238,7 +241,7 @@ void PrivacyDialog::on_pushButtonMintzGALI_clicked()
 
     return;
 }
-
+*/
 void PrivacyDialog::on_pushButtonMintReset_clicked()
 {
     ui->TEMintStatus->setPlainText(tr("Starting ResetMintZerocoin: rescanning complete blockchain, this will need up to 30 minutes depending on your hardware.\nPlease be patient..."));
@@ -524,6 +527,8 @@ void PrivacyDialog::on_payTo_textChanged(const QString& address)
     updateLabel(address);
 }
 
+/* DISABLE MINTs: no need for coinCointrol
+
 // Coin Control: copy label "Quantity" to clipboard
 void PrivacyDialog::coinControlClipboardQuantity()
 {
@@ -565,7 +570,7 @@ void PrivacyDialog::coinControlUpdateLabels()
         ui->labelCoinControlAmount->setText (tr("Coins automatically selected"));
     }
 }
-
+*/
 
 void PrivacyDialog::on_pushButtonShowDenoms_clicked()
 {
@@ -711,7 +716,6 @@ void PrivacyDialog::setBalance(const CAmount& balance, const CAmount& unconfirme
     ui->labelzAvailableAmount->setText(QString::number(zerocoinBalance/COIN) + QString(" zGALI "));
     ui->labelzAvailableAmount_2->setText(QString::number(matureZerocoinBalance/COIN) + QString(" zGALI "));
     ui->labelzAvailableAmount_4->setText(QString::number(zerocoinBalance/COIN) + QString(" zGALI "));
-    ui->labelzGALIAmountValue->setText(BitcoinUnits::floorHtmlWithUnit(nDisplayUnit, balance - immatureBalance - nLockedBalance, false, BitcoinUnits::separatorAlways));
 
     // Display AutoMint status
     updateAutomintStatus();
@@ -803,20 +807,21 @@ void PrivacyDialog::updateAutomintStatus()
 void PrivacyDialog::updateSPORK16Status()
 {
     // Update/enable labels, buttons and tooltips depending on the current SPORK_16 status
-    bool fButtonsEnabled =  ui->pushButtonMintzGALI->isEnabled();
+    //bool fButtonsEnabled =  ui->pushButtonMintzGALI->isEnabled();
+    bool fButtonsEnabled = false;
     bool fMaintenanceMode = GetAdjustedTime() > GetSporkValue(SPORK_16_ZEROCOIN_MAINTENANCE_MODE);
     if (fMaintenanceMode && fButtonsEnabled) {
         // Mint zGALI
-        ui->pushButtonMintzGALI->setEnabled(false);
-        ui->pushButtonMintzGALI->setToolTip(tr("zGALI is currently disabled due to maintenance."));
+        //ui->pushButtonMintzGALI->setEnabled(false);
+        //ui->pushButtonMintzGALI->setToolTip(tr("zGALI is currently disabled due to maintenance."));
 
         // Spend zGALI
         ui->pushButtonSpendzGALI->setEnabled(false);
         ui->pushButtonSpendzGALI->setToolTip(tr("zGALI is currently disabled due to maintenance."));
     } else if (!fMaintenanceMode && !fButtonsEnabled) {
         // Mint zGALI
-        ui->pushButtonMintzGALI->setEnabled(true);
-        ui->pushButtonMintzGALI->setToolTip(tr("PrivacyDialog", "Enter an amount of GALI to convert to zGALI", 0));
+        //ui->pushButtonMintzGALI->setEnabled(true);
+        //ui->pushButtonMintzGALI->setToolTip(tr("PrivacyDialog", "Enter an amount of GALI to convert to zGALI", 0));
 
         // Spend zGALI
         ui->pushButtonSpendzGALI->setEnabled(true);

--- a/src/qt/privacydialog.cpp
+++ b/src/qt/privacydialog.cpp
@@ -111,6 +111,8 @@ PrivacyDialog::PrivacyDialog(QWidget* parent) : QDialog(parent, Qt::WindowSystem
     if(!settings.contains("fDenomsSectionMinimized"))
         settings.setValue("fDenomsSectionMinimized", true);
     minimizeDenomsSection(settings.value("fDenomsSectionMinimized").toBool());
+
+    ui->checkBoxMintChange->setVisible(false);
 }
 
 PrivacyDialog::~PrivacyDialog()
@@ -345,7 +347,7 @@ void PrivacyDialog::sendzGALI()
     }
 
     // Convert change to zGALI
-    bool fMintChange = ui->checkBoxMintChange->isChecked();
+    bool fMintChange = false;// ui->checkBoxMintChange->isChecked();
 
     // Persist minimize change setting
     fMinimizeChange = ui->checkBoxMinimizeChange->isChecked();
@@ -440,6 +442,7 @@ void PrivacyDialog::sendzGALI()
 
     // Display errors during spend
     if (!fSuccess) {
+        /*
         int nNeededSpends = receipt.GetNeededSpends(); // Number of spends we would need for this transaction
         const int nMaxSpends = Params().Zerocoin_MaxSpendsPerTransaction(); // Maximum possible spends for one zGALI transaction
         if (nNeededSpends > nMaxSpends) {
@@ -449,9 +452,10 @@ void PrivacyDialog::sendzGALI()
             ui->TEMintStatus->setPlainText(tr("Spend Zerocoin failed with status = ") +QString::number(receipt.GetStatus(), 10) + "\n" + "Message: " + QString::fromStdString(strStatusMessage.toStdString()));
         }
         else {
-            QMessageBox::warning(this, tr("Spend Zerocoin"), receipt.GetStatusMessage().c_str(), QMessageBox::Ok, QMessageBox::Ok);
-            ui->TEMintStatus->setPlainText(tr("Spend Zerocoin failed with status = ") +QString::number(receipt.GetStatus(), 10) + "\n" + "Message: " + QString::fromStdString(receipt.GetStatusMessage()));
-        }
+         */
+        QMessageBox::warning(this, tr("Spend Zerocoin"), receipt.GetStatusMessage().c_str(), QMessageBox::Ok, QMessageBox::Ok);
+        ui->TEMintStatus->setPlainText(tr("Spend Zerocoin failed with status = ") +QString::number(receipt.GetStatus(), 10) + "\n" + "Message: " + QString::fromStdString(receipt.GetStatusMessage()));
+        //}
         ui->zGALIpayAmount->setFocus();
         ui->TEMintStatus->repaint();
         ui->TEMintStatus->verticalScrollBar()->setValue(ui->TEMintStatus->verticalScrollBar()->maximum()); // Automatically scroll to end of text

--- a/src/qt/privacydialog.h
+++ b/src/qt/privacydialog.h
@@ -84,13 +84,13 @@ private slots:
     void on_payTo_textChanged(const QString& address);
     void on_addressBookButton_clicked();
 //    void coinControlFeatureChanged(bool);
-    void coinControlButtonClicked();
+// MINT disabled   void coinControlButtonClicked();
 //    void coinControlChangeChecked(int);
 //    void coinControlChangeEdited(const QString&);
-    void coinControlUpdateLabels();
+// MINT disabled    void coinControlUpdateLabels();
 
-    void coinControlClipboardQuantity();
-    void coinControlClipboardAmount();
+// MINT disabled    void coinControlClipboardQuantity();
+// MINT disabled    void coinControlClipboardAmount();
 //    void coinControlClipboardFee();
 //    void coinControlClipboardAfterFee();
 //    void coinControlClipboardBytes();
@@ -98,7 +98,7 @@ private slots:
 //    void coinControlClipboardLowOutput();
 //    void coinControlClipboardChange();
 
-    void on_pushButtonMintzGALI_clicked();
+// MINT disabled    void on_pushButtonMintzGALI_clicked();
     void on_pushButtonMintReset_clicked();
     void on_pushButtonSpentReset_clicked();
     void on_pushButtonSpendzGALI_clicked();

--- a/src/qt/zgalicontroldialog.cpp
+++ b/src/qt/zgalicontroldialog.cpp
@@ -82,7 +82,7 @@ void ZGaliControlDialog::updateList()
 
     //populate rows with mint info
     int nBestHeight = chainActive.Height();
-    map<CoinDenomination, int> mapMaturityHeight = GetMintMaturityHeight();
+    //map<CoinDenomination, int> mapMaturityHeight = GetMintMaturityHeight();
     for (const CMintMeta& mint : setMints) {
         // assign this mint to the correct denomination in the tree view
         libzerocoin::CoinDenomination denom = mint.denom;
@@ -125,9 +125,10 @@ void ZGaliControlDialog::updateList()
         }
 
         // check for maturity
-        bool isMature = false;
-        if (mapMaturityHeight.count(mint.denom))
-            isMature = mint.nHeight < mapMaturityHeight.at(denom);
+        // Always mature, public spends doesn't require any new accumulation.
+        bool isMature = true;
+        //if (mapMaturityHeight.count(mint.denom))
+        //    isMature = mint.nHeight < mapMaturityHeight.at(denom);
 
         // disable selecting this mint if it is not spendable - also display a reason why
         bool fSpendable = isMature && nConfirmations >= Params().Zerocoin_MintRequiredConfirmations() && mint.isSeedCorrect;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -19,6 +19,7 @@
 #include "zgali/accumulatormap.h"
 #include "zgali/accumulators.h"
 #include "wallet/wallet.h"
+#include "zgali/zgalimodule.h"
 #include "zgalichain.h"
 
 #include <stdint.h>
@@ -1008,7 +1009,7 @@ UniValue getfeeinfo(const UniValue& params, bool fHelp)
                 continue;
 
             for (unsigned int j = 0; j < tx.vin.size(); j++) {
-                if (tx.vin[j].IsZerocoinSpend()) {
+                if (tx.vin[j].IsZerocoinSpend() || tx.vin[j].IsZerocoinPublicSpend()) {
                     nValueIn += tx.vin[j].nSequence * COIN;
                     continue;
                 }
@@ -1403,13 +1404,31 @@ UniValue getserials(const UniValue& params, bool fHelp) {
             }
             // loop through each input
             for (const CTxIn& txin : tx.vin) {
-                if (txin.IsZerocoinSpend()) {
-                    libzerocoin::CoinSpend spend = TxInToZerocoinSpend(txin);
-                    std::string serial_str = spend.getCoinSerialNumber().ToString(16);
+                bool isPublicSpend =  txin.IsZerocoinPublicSpend();
+                if (txin.IsZerocoinSpend() || isPublicSpend) {
+                    std::string serial_str;
+                    int denom;
+                    if (isPublicSpend) {
+                        CTxOut prevOut;
+                        CValidationState state;
+                        if(!GetOutput(txin.prevout.hash, txin.prevout.n, state, prevOut)){
+                            throw JSONRPCError(RPC_INTERNAL_ERROR, "public zerocoin spend prev output not found");
+                        }
+                        libzerocoin::ZerocoinParams *params = Params().Zerocoin_Params(false);
+                        PublicCoinSpend publicSpend(params);
+                        if (!ZGALIModule::parseCoinSpend(txin, tx, prevOut, publicSpend)) {
+                            throw JSONRPCError(RPC_INTERNAL_ERROR, "public zerocoin spend parse failed");
+                        }
+                        serial_str = publicSpend.getCoinSerialNumber().ToString(16);
+                        denom = libzerocoin::ZerocoinDenominationToInt(publicSpend.getDenomination());
+                    } else {
+                        libzerocoin::CoinSpend spend = TxInToZerocoinSpend(txin);
+                        serial_str = spend.getCoinSerialNumber().ToString(16);
+                        denom = libzerocoin::ZerocoinDenominationToInt(spend.getDenomination());
+                    }
                     if (!fVerbose) {
                         serialsArr.push_back(serial_str);
                     } else {
-                        int denom = libzerocoin::ZerocoinDenominationToInt(spend.getDenomination());
                         UniValue s(UniValue::VOBJ);
                         s.push_back(Pair("serial", serial_str));
                         s.push_back(Pair("denom", denom));
@@ -1420,7 +1439,6 @@ UniValue getserials(const UniValue& params, bool fHelp) {
                         s.push_back(Pair("blocktime", block.GetBlockTime()));
                         serialsArr.push_back(s);
                     }
-
                 }
 
             } // end for vin in tx

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -993,4 +993,68 @@ UniValue createrawzerocoinstake(const UniValue& params, bool fHelp)
     return ret;
 
 }
+
+UniValue createrawzerocoinpublicspend(const UniValue& params, bool fHelp)
+{
+    if (fHelp || params.size() < 1 || params.size() > 2)
+        throw runtime_error(
+            "createrawzerocoinpublicspend mint_input \n"
+            "\nCreates raw zGALI public spend.\n" +
+            HelpRequiringPassphrase() + "\n"
+
+            "\nArguments:\n"
+            "1. mint_input      (hex string, required) serial hash of the mint used as input\n"
+            "2. \"address\"     (string, optional, default=change) Send to specified address or to a new change address.\n"
+
+
+            "\nResult:\n"
+            "{\n"
+            "   \"hex\": \"xxx\",           (hex string) raw public spend signed transaction\n"
+            "}\n"
+            "\nExamples\n" +
+            HelpExampleCli("createrawzerocoinpublicspend", "0d8c16eee7737e3cc1e4e70dc006634182b175e039700931283b202715a0818f") +
+            HelpExampleRpc("createrawzerocoinpublicspend", "0d8c16eee7737e3cc1e4e70dc006634182b175e039700931283b202715a0818f"));
+
+
+    assert(pwalletMain != NULL);
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
+    std::string serial_hash = params[0].get_str();
+    if (!IsHex(serial_hash))
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, expected hex serial hash");
+
+    std::string address_str = "";
+    CBitcoinAddress address;
+    CBitcoinAddress* addr_ptr = nullptr;
+    if (params.size() > 1) {
+        address_str = params[1].get_str();
+        address = CBitcoinAddress(address_str);
+        if(!address.IsValid())
+            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid GALI address");
+        addr_ptr = &address;
+    }
+
+    EnsureWalletIsUnlocked();
+
+    uint256 hashSerial(serial_hash);
+    CZerocoinMint input_mint;
+    if (!pwalletMain->GetMint(hashSerial, input_mint)) {
+        std::string strErr = "Failed to fetch mint associated with serial hash " + serial_hash;
+        throw JSONRPCError(RPC_WALLET_ERROR, strErr);
+    }
+    CAmount nAmount = input_mint.GetDenominationAsAmount();
+    vector<CZerocoinMint> vMintsSelected = vector<CZerocoinMint>(1,input_mint);
+
+    // create the spend
+    CWalletTx rawTx;
+    CZerocoinSpendReceipt receipt;
+    CReserveKey reserveKey(pwalletMain);
+    vector<CDeterministicMint> vNewMints;
+    if (!pwalletMain->CreateZerocoinSpendTransaction(nAmount, rawTx, reserveKey, receipt, vMintsSelected, vNewMints, false, true, addr_ptr, true))
+        throw JSONRPCError(RPC_WALLET_ERROR, receipt.GetStatusMessage());
+
+    // output the raw transaction
+    return EncodeHexTx(rawTx);
+}
 #endif
+

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -448,6 +448,7 @@ static const CRPCCommand vRPCCommands[] =
         {"wallet", "walletpassphrase", &walletpassphrase, true, false, true},
 
         {"zerocoin", "createrawzerocoinstake", &createrawzerocoinstake, false, false, true},
+        {"zerocoin", "createrawzerocoinpublicspend", &createrawzerocoinpublicspend, false, false, true},
         {"zerocoin", "getzerocoinbalance", &getzerocoinbalance, false, false, true},
         {"zerocoin", "listmintedzerocoins", &listmintedzerocoins, false, false, true},
         {"zerocoin", "listspentzerocoins", &listspentzerocoins, false, false, true},

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -182,7 +182,7 @@ extern std::string HelpExampleCli(std::string methodname, std::string args);
 extern std::string HelpExampleRpc(std::string methodname, std::string args);
 
 extern void EnsureWalletIsUnlocked(bool fAllowAnonOnly = false);
-extern UniValue DoZgaliSpend(const CAmount nAmount, bool fMintChange, bool fMinimizeChange, vector<CZerocoinMint>& vMintsSelected, std::string address_str);
+extern UniValue DoZgaliSpend(const CAmount nAmount, bool fMintChange, bool fMinimizeChange, vector<CZerocoinMint>& vMintsSelected, std::string address_str, bool isPublicSpend = true);
 
 extern UniValue getconnectioncount(const UniValue& params, bool fHelp); // in rpc/net.cpp
 extern UniValue getpeerinfo(const UniValue& params, bool fHelp);
@@ -287,6 +287,7 @@ extern UniValue decodescript(const UniValue& params, bool fHelp);
 extern UniValue signrawtransaction(const UniValue& params, bool fHelp);
 extern UniValue sendrawtransaction(const UniValue& params, bool fHelp);
 extern UniValue createrawzerocoinstake(const UniValue& params, bool fHelp);
+extern UniValue createrawzerocoinpublicspend(const UniValue& params, bool fHelp);
 
 extern UniValue findserial(const UniValue& params, bool fHelp); // in rpc/blockchain.cpp
 extern UniValue getblockcount(const UniValue& params, bool fHelp);

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -157,6 +157,7 @@ const char* GetOpName(opcodetype opcode)
     // zerocoin
     case OP_ZEROCOINMINT           : return "OP_ZEROCOINMINT";
     case OP_ZEROCOINSPEND          : return "OP_ZEROCOINSPEND";
+    case OP_ZEROCOINPUBLICSPEND          : return "OP_ZEROCOINPUBLICSPEND";
 
     case OP_INVALIDOPCODE          : return "OP_INVALIDOPCODE";
 
@@ -264,6 +265,11 @@ bool CScript::IsZerocoinMint() const
 bool CScript::IsZerocoinSpend() const
 {
     return StartsWithOpcode(OP_ZEROCOINSPEND);
+}
+
+bool CScript::IsZerocoinPublicSpend() const
+{
+    return StartsWithOpcode(OP_ZEROCOINPUBLICSPEND);
 }
 
 bool CScript::IsPushOnly(const_iterator pc) const

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -168,6 +168,7 @@ enum opcodetype
     // zerocoin
     OP_ZEROCOINMINT = 0xc1,
     OP_ZEROCOINSPEND = 0xc2,
+    OP_ZEROCOINPUBLICSPEND = 0xc3,
 
     // template matching params
     OP_SMALLINTEGER = 0xfa,
@@ -597,6 +598,7 @@ public:
     bool StartsWithOpcode(const opcodetype opcode) const;
     bool IsZerocoinMint() const;
     bool IsZerocoinSpend() const;
+    bool IsZerocoinPublicSpend() const;
 
     /** Called by IsStandardTx and P2SH/BIP62 VerifyScript (which makes it consensus-critical). */
     bool IsPushOnly(const_iterator pc) const;

--- a/src/test/zerocoin_transactions_tests.cpp
+++ b/src/test/zerocoin_transactions_tests.cpp
@@ -5,6 +5,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "libzerocoin/Denominations.h"
+#include "libzerocoin/Coin.h"
 #include "amount.h"
 #include "chainparams.h"
 #include "coincontrol.h"
@@ -12,13 +13,15 @@
 #include "wallet/wallet.h"
 #include "wallet/walletdb.h"
 #include "txdb.h"
+#include "zgali/zgalimodule.h"
+#include "test/test_galilel.h"
 #include <boost/test/unit_test.hpp>
 #include <iostream>
 
 using namespace libzerocoin;
 
 
-BOOST_AUTO_TEST_SUITE(zerocoin_transactions_tests)
+BOOST_FIXTURE_TEST_SUITE(zerocoin_transactions_tests, TestingSetup)
 
 static CWallet cWallet("unlocked.dat");
 
@@ -42,7 +45,7 @@ BOOST_AUTO_TEST_CASE(zerocoin_spend_test)
     CZerocoinSpendReceipt receipt;
     cWallet.SpendZerocoin(nAmount, *wtx, receipt, vMints, fMintChange, fMinimizeChange);
 
-    BOOST_CHECK_MESSAGE(receipt.GetStatus() == ZGALI_TRX_FUNDS_PROBLEMS, "Failed Invalid Amount Check");
+    BOOST_CHECK_MESSAGE(receipt.GetStatus() == ZGALI_TRX_FUNDS_PROBLEMS, strprintf("Failed Invalid Amount Check: %s", receipt.GetStatusMessage()));
 
     nAmount = 1;
     CZerocoinSpendReceipt receipt2;
@@ -51,7 +54,68 @@ BOOST_AUTO_TEST_CASE(zerocoin_spend_test)
     // if using "wallet.dat", instead of "unlocked.dat" need this
     /// BOOST_CHECK_MESSAGE(vString == "Error: Wallet locked, unable to create transaction!"," Locked Wallet Check Failed");
 
-    BOOST_CHECK_MESSAGE(receipt2.GetStatus() == ZGALI_TRX_FUNDS_PROBLEMS, "Failed Invalid Amount Check");
+    BOOST_CHECK_MESSAGE(receipt2.GetStatus() == ZGALI_TRX_FUNDS_PROBLEMS, strprintf("Failed Invalid Amount Check: %s", receipt.GetStatusMessage()));
+
+}
+
+BOOST_AUTO_TEST_CASE(zerocoin_public_spend_test)
+{
+    SelectParams(CBaseChainParams::MAIN);
+    ZerocoinParams *ZCParams = Params().Zerocoin_Params(false);
+    (void)ZCParams;
+
+    PrivateCoin privCoin(ZCParams, libzerocoin::CoinDenomination::ZQ_ONE, true);
+    const CPrivKey privKey = privCoin.getPrivKey();
+
+    CZerocoinMint mint = CZerocoinMint(
+            privCoin.getPublicCoin().getDenomination(),
+            privCoin.getPublicCoin().getValue(),
+            privCoin.getRandomness(),
+            privCoin.getSerialNumber(),
+            false,
+            privCoin.getVersion(),
+            nullptr);
+    mint.SetPrivKey(privKey);
+
+
+    // Mint tx
+    CTransaction prevTx;
+
+    CScript scriptSerializedCoin = CScript()
+    << OP_ZEROCOINMINT << privCoin.getPublicCoin().getValue().getvch().size() << privCoin.getPublicCoin().getValue().getvch();
+    CTxOut out = CTxOut(libzerocoin::ZerocoinDenominationToAmount(privCoin.getPublicCoin().getDenomination()), scriptSerializedCoin);
+    prevTx.vout.push_back(out);
+
+    mint.SetOutputIndex(0);
+    mint.SetTxHash(prevTx.GetHash());
+
+    // Spend tx
+    CMutableTransaction tx;
+    tx.vout.resize(1);
+    tx.vout[0].nValue = 1*CENT;
+    tx.vout[0].scriptPubKey = GetScriptForDestination(CBitcoinAddress("D9Ti4LEhF1n6dR2hGd2SyNADD51AVgva6q").Get());
+
+    CTxIn in;
+    if (!ZGALIModule::createInput(in, mint, tx.GetHash())){
+        BOOST_CHECK_MESSAGE(false, "Failed to create zc input");
+    }
+
+    PublicCoinSpend publicSpend(ZCParams);
+    if (!ZGALIModule::validateInput(in, out, tx, publicSpend)){
+        BOOST_CHECK_MESSAGE(false, "Failed to validate zc input");
+    }
+
+    PublicCoinSpend publicSpendTest(ZCParams);
+    BOOST_CHECK_MESSAGE(ZGALIModule::parseCoinSpend(in, tx, out, publicSpendTest), "Failed to parse public spend");
+    libzerocoin::CoinSpend *spend = &publicSpendTest;
+
+    BOOST_CHECK_MESSAGE(publicSpendTest.HasValidSignature(), "Failed to validate public spend signature");
+    BOOST_CHECK_MESSAGE(spend->HasValidSignature(), "Failed to validate spend signature");
+
+    // Verify that fails with a different denomination
+    in.nSequence = 500;
+    PublicCoinSpend publicSpend2(ZCParams);
+    BOOST_CHECK_MESSAGE(!ZGALIModule::validateInput(in, out, tx, publicSpend2), "Different denomination");
 
 }
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -568,11 +568,11 @@ void CTxMemPool::check(const CCoinsViewCache* pcoins) const
                 fDependsWait = true;
             } else {
                 const CCoins* coins = pcoins->AccessCoins(txin.prevout.hash);
-                if(!txin.IsZerocoinSpend())
+                if(!txin.IsZerocoinSpend() && !txin.IsZerocoinPublicSpend())
                     assert(coins && coins->IsAvailable(txin.prevout.n));
             }
             // Check whether its inputs are marked in mapNextTx.
-            if(!txin.IsZerocoinSpend()) {
+            if(!txin.IsZerocoinSpend()  && !txin.IsZerocoinPublicSpend()) {
                 std::map<COutPoint, CInPoint>::const_iterator it3 = mapNextTx.find(txin.prevout);
                 assert(it3 != mapNextTx.end());
                 assert(it3->second.ptx == &tx);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2771,6 +2771,10 @@ UniValue mintzerocoin(const UniValue& params, bool fHelp)
             "\nAs a json rpc call\n" +
             HelpExampleRpc("mintzerocoin", "13, \"[{\\\"txid\\\":\\\"a08e6907dbbd3d809776dbfc5d82e371b764ed838b5655e72f463568df1aadf0\\\",\\\"vout\\\":1}]\""));
 
+
+    if (Params().NetworkID() != CBaseChainParams::REGTEST)
+        throw JSONRPCError(RPC_WALLET_ERROR, "zGALI minting is DISABLED");
+
     LOCK2(cs_main, pwalletMain->cs_wallet);
 
     if (params.size() == 1)
@@ -2893,6 +2897,8 @@ UniValue spendzerocoin(const UniValue& params, bool fHelp)
 
     CAmount nAmount = AmountFromValue(params[0]);   // Spending amount
     bool fMintChange = params[1].get_bool();        // Mint change to zGALI
+    if (fMintChange && Params().NetworkID() != CBaseChainParams::REGTEST)
+        throw JSONRPCError(RPC_WALLET_ERROR, "zGALI minting is DISABLED, cannot mint change");
     bool fMinimizeChange = params[2].get_bool();    // Minimize change
     std::string address_str = params.size() > 3 ? params[3].get_str() : "";
     bool ispublicspend = params.size() > 4 ? params[3].get_bool() : true;
@@ -3003,6 +3009,10 @@ UniValue spendzerocoinmints(const UniValue& params, bool fHelp)
 
 extern UniValue DoZgaliSpend(const CAmount nAmount, bool fMintChange, bool fMinimizeChange, vector<CZerocoinMint>& vMintsSelected, std::string address_str, bool ispublicspend)
 {
+    // zerocoin MINT is disabled. fMintChange should be false here. Double check
+    if (fMintChange && Params().NetworkID() != CBaseChainParams::REGTEST)
+        throw JSONRPCError(RPC_WALLET_ERROR, "zGALI minting is DISABLED, cannot mint change");
+
     int64_t nTimeStart = GetTimeMillis();
     CBitcoinAddress address = CBitcoinAddress(); // Optional sending address. Dummy initialization here.
     CWalletTx wtx;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2855,6 +2855,7 @@ UniValue spendzerocoin(const UniValue& params, bool fHelp)
             "3. minimizechange  (boolean, required) Try to minimize the returning change  [false]\n"
             "4. \"address\"     (string, optional, default=change) Send to specified address or to a new change address.\n"
             "                       If there is change then an address is required\n"
+            "5. ispublicspend (boolean, optional, default=true) create a public zc spend instead of use the old code (only for regression tests)"
 
             "\nResult:\n"
             "{\n"
@@ -2894,10 +2895,15 @@ UniValue spendzerocoin(const UniValue& params, bool fHelp)
     bool fMintChange = params[1].get_bool();        // Mint change to zGALI
     bool fMinimizeChange = params[2].get_bool();    // Minimize change
     std::string address_str = params.size() > 3 ? params[3].get_str() : "";
+    bool ispublicspend = params.size() > 4 ? params[3].get_bool() : true;
 
     vector<CZerocoinMint> vMintsSelected;
 
-    return DoZgaliSpend(nAmount, fMintChange, fMinimizeChange, vMintsSelected, address_str);
+    if (!ispublicspend && Params().NetworkID() != CBaseChainParams::REGTEST) {
+        throw JSONRPCError(RPC_WALLET_ERROR, "zGALI old spend only available in regtest for tests purposes");
+    }
+
+    return DoZgaliSpend(nAmount, fMintChange, fMinimizeChange, vMintsSelected, address_str, ispublicspend);
 }
 
 
@@ -2995,7 +3001,7 @@ UniValue spendzerocoinmints(const UniValue& params, bool fHelp)
 }
 
 
-extern UniValue DoZgaliSpend(const CAmount nAmount, bool fMintChange, bool fMinimizeChange, vector<CZerocoinMint>& vMintsSelected, std::string address_str)
+extern UniValue DoZgaliSpend(const CAmount nAmount, bool fMintChange, bool fMinimizeChange, vector<CZerocoinMint>& vMintsSelected, std::string address_str, bool ispublicspend)
 {
     int64_t nTimeStart = GetTimeMillis();
     CBitcoinAddress address = CBitcoinAddress(); // Optional sending address. Dummy initialization here.
@@ -3007,9 +3013,9 @@ extern UniValue DoZgaliSpend(const CAmount nAmount, bool fMintChange, bool fMini
         address = CBitcoinAddress(address_str);
         if(!address.IsValid())
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid GALI address");
-        fSuccess = pwalletMain->SpendZerocoin(nAmount, wtx, receipt, vMintsSelected, fMintChange, fMinimizeChange, &address);
+        fSuccess = pwalletMain->SpendZerocoin(nAmount, wtx, receipt, vMintsSelected, fMintChange, fMinimizeChange, &address, ispublicspend);
     } else                   // Spend to newly generated local address
-        fSuccess = pwalletMain->SpendZerocoin(nAmount, wtx, receipt, vMintsSelected, fMintChange, fMinimizeChange);
+        fSuccess = pwalletMain->SpendZerocoin(nAmount, wtx, receipt, vMintsSelected, fMintChange, fMinimizeChange, nullptr, ispublicspend);
 
     if (!fSuccess)
         throw JSONRPCError(RPC_WALLET_ERROR, receipt.GetStatusMessage());

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1662,20 +1662,25 @@ CAmount CWallet::GetBalance() const
     return nTotal;
 }
 
-std::map<libzerocoin::CoinDenomination, int> mapMintMaturity;
-int nLastMaturityCheck = 0;
+//std::map<libzerocoin::CoinDenomination, int> mapMintMaturity;
+//int nLastMaturityCheck = 0;
+
 CAmount CWallet::GetZerocoinBalance(bool fMatureOnly) const
 {
     if (fMatureOnly) {
-        if (chainActive.Height() > nLastMaturityCheck)
-            mapMintMaturity = GetMintMaturityHeight();
-        nLastMaturityCheck = chainActive.Height();
+        // This code is not removed just for when we back to use zGALI in the future, for now it's useless,
+        // every public coin spend is now spendable without need to have new mints on top.
+
+        //if (chainActive.Height() > nLastMaturityCheck)
+        //    mapMintMaturity = GetMintMaturityHeight();
+        //nLastMaturityCheck = chainActive.Height();
 
         CAmount nBalance = 0;
         vector<CMintMeta> vMints = zgaliTracker->GetMints(true);
         for (auto meta : vMints) {
-            if (meta.nHeight >= mapMintMaturity.at(meta.denom) || meta.nHeight >= chainActive.Height() || meta.nHeight == 0)
-                continue;
+            // Every public coin spend is now spendable, no need to mint new coins on top.
+            //if (meta.nHeight >= mapMintMaturity.at(meta.denom) || meta.nHeight >= chainActive.Height() || meta.nHeight == 0)
+            //    continue;
             nBalance += libzerocoin::ZerocoinDenominationToAmount(meta.denom);
         }
         return nBalance;
@@ -3116,7 +3121,7 @@ bool CWallet::CreateCoinStake(
 
     // Sign for GALI
     int nIn = 0;
-    if (!txNew.vin[0].IsZerocoinSpend()) {
+    if (!txNew.vin[0].scriptSig.IsZerocoinSpend()) {
         for (CTxIn txIn : txNew.vin) {
             const CWalletTx *wtx = GetWalletTx(txIn.prevout.hash);
             if (!SignSignature(*this, *wtx, txNew, nIn++))
@@ -4703,14 +4708,28 @@ bool CWallet::CheckCoinSpend(libzerocoin::CoinSpend& spend, libzerocoin::Accumul
     return true;
 }
 
-bool CWallet::MintToTxIn(CZerocoinMint mint, const uint256& hashTxOut, CTxIn& newTxIn, CZerocoinSpendReceipt& receipt, libzerocoin::SpendType spendType, CBlockIndex* pindexCheckpoint)
+bool CWallet::MintToTxIn(
+        CZerocoinMint mint,
+        const uint256& hashTxOut,
+        CTxIn& newTxIn,
+        CZerocoinSpendReceipt& receipt,
+        libzerocoin::SpendType spendType,
+        CBlockIndex* pindexCheckpoint,
+        bool publicCoinSpend)
 {
     std::map<CBigNum, CZerocoinMint> mapMints;
     mapMints.insert(std::make_pair(mint.GetValue(), mint));
     std::vector<CTxIn> vin;
-    if (MintsToInputVector(mapMints, hashTxOut, vin, receipt, spendType, pindexCheckpoint)) {
-        newTxIn = vin[0];
-        return true;
+    if (publicCoinSpend) {
+        if (MintsToInputVectorPublicSpend(mapMints, hashTxOut, vin, receipt, spendType, pindexCheckpoint)) {
+            newTxIn = vin[0];
+            return true;
+        }
+    } else {
+        if (MintsToInputVector(mapMints, hashTxOut, vin, receipt, spendType, pindexCheckpoint)) {
+            newTxIn = vin[0];
+            return true;
+        }
     }
 
     return false;
@@ -4822,7 +4841,93 @@ bool CWallet::MintsToInputVector(std::map<CBigNum, CZerocoinMint>& mapMintsSelec
     return true;
 }
 
-bool CWallet::CreateZerocoinSpendTransaction(CAmount nValue, CWalletTx& wtxNew, CReserveKey& reserveKey, CZerocoinSpendReceipt& receipt, vector<CZerocoinMint>& vSelectedMints, vector<CDeterministicMint>& vNewMints, bool fMintChange,  bool fMinimizeChange, CBitcoinAddress* address)
+bool CWallet::MintsToInputVectorPublicSpend(std::map<CBigNum, CZerocoinMint>& mapMintsSelected, const uint256& hashTxOut, std::vector<CTxIn>& vin,
+                                    CZerocoinSpendReceipt& receipt, libzerocoin::SpendType spendType, CBlockIndex* pindexCheckpoint)
+{
+    // Default error status if not changed below
+    receipt.SetStatus(_("Transaction Mint Started"), ZGALI_TXMINT_GENERAL);
+
+    int nLockAttempts = 0;
+    while (nLockAttempts < 100) {
+        TRY_LOCK(zgaliTracker->cs_spendcache, lockSpendcache);
+        if (!lockSpendcache) {
+            fGlobalUnlockSpendCache = true;
+            MilliSleep(100);
+            ++nLockAttempts;
+            continue;
+        }
+
+        for (auto &it : mapMintsSelected) {
+            CZerocoinMint mint = it.second;
+
+            // Create the simple input and the scriptSig -> Serial + Randomness + Private key signature of both.
+            // As the mint doesn't have the output index search it..
+            CTransaction txMint;
+            uint256 hashBlock;
+            if (!GetTransaction(mint.GetTxHash(), txMint, hashBlock)) {
+                receipt.SetStatus(strprintf(_("Unable to find transaction containing mint %s"), mint.GetTxHash().GetHex()), ZGALI_TXMINT_GENERAL);
+                return false;
+            } else if (mapBlockIndex.count(hashBlock) < 1) {
+                // check that this mint made it into the blockchain
+                receipt.SetStatus(_("Mint did not make it into blockchain"), ZGALI_TXMINT_GENERAL);
+                return false;
+            }
+
+            int outputIndex = -1;
+            for (unsigned long i = 0; i < txMint.vout.size(); ++i) {
+                CTxOut out = txMint.vout[i];
+                if (out.scriptPubKey.IsZerocoinMint()){
+                    libzerocoin::PublicCoin pubcoin(Params().Zerocoin_Params(false));
+                    CValidationState state;
+                    if (!TxOutToPublicCoin(out, pubcoin, state))
+                        return error("%s: extracting pubcoin from txout failed", __func__);
+
+                    if (pubcoin.getValue() == mint.GetValue()){
+                        outputIndex = i;
+                        break;
+                    }
+                }
+            }
+
+            if (outputIndex == -1) {
+                receipt.SetStatus(_("Pubcoin not found in mint tx"), ZGALI_TXMINT_GENERAL);
+                return false;
+            }
+
+            mint.SetOutputIndex(outputIndex);
+            CTxIn in;
+            if(!ZGALIModule::createInput(in, mint, hashTxOut)){
+                receipt.SetStatus(_("Cannot create public spend input"), ZGALI_TXMINT_GENERAL);
+                return false;
+            }
+            vin.emplace_back(in);
+            receipt.AddSpend(CZerocoinSpend(mint.GetSerialNumber(), 0, mint.GetValue(), mint.GetDenomination(), 0));
+        }
+        break;
+    }
+
+    if (nLockAttempts == 100) {
+        LogPrintf("%s : could not get lock on cs_spendcache\n", __func__);
+        receipt.SetStatus(_("could not get lock on cs_spendcache"), ZGALI_TXMINT_GENERAL);
+        return false;
+    }
+
+    receipt.SetStatus(_("Spend Valid"), ZGALI_SPEND_OKAY); // Everything okay
+
+    return true;
+}
+
+bool CWallet::CreateZerocoinSpendTransaction(
+        CAmount nValue,
+        CWalletTx& wtxNew,
+        CReserveKey& reserveKey,
+        CZerocoinSpendReceipt& receipt,
+        vector<CZerocoinMint>& vSelectedMints,
+        vector<CDeterministicMint>& vNewMints,
+        bool fMintChange,
+        bool fMinimizeChange,
+        CBitcoinAddress* address,
+        bool isPublicSpend)
 {
     // Check available funds
     int nStatus = ZGALI_TRX_FUNDS_PROBLEMS;
@@ -4845,10 +4950,11 @@ bool CWallet::CreateZerocoinSpendTransaction(CAmount nValue, CWalletTx& wtxNew, 
     CAmount nValueSelected = 0;
     int nCoinsReturned = 0; // Number of coins returned in change from function below (for debug)
     int nNeededSpends = 0;  // Number of spends which would be needed if selection failed
-    const int nMaxSpends = Params().Zerocoin_MaxSpendsPerTransaction(); // Maximum possible spends for one zGALI transaction
+    const int nMaxSpends = Params().Zerocoin_MaxPublicSpendsPerTransaction(); // Maximum possible spends for one zGALI public spend transaction
     vector<CMintMeta> vMintsToFetch;
     if (vSelectedMints.empty()) {
-        setMints = zgaliTracker->ListMints(true, true, true); // need to find mints to spend
+        //  All of the zGALI used in the public coin spend are mature by default (everything is public now.. no need to wait for any accumulation)
+        setMints = zgaliTracker->ListMints(true, false, true, true); // need to find mints to spend
         if(setMints.empty()) {
             receipt.SetStatus(_("Failed to find Zerocoins in wallet.dat"), nStatus);
             return false;
@@ -4909,7 +5015,7 @@ bool CWallet::CreateZerocoinSpendTransaction(CAmount nValue, CWalletTx& wtxNew, 
         uint256 hashBlock;
         bool fArchive = false;
         if (!GetTransaction(mint.GetTxHash(), txMint, hashBlock)) {
-            receipt.SetStatus(_("Unable to find transaction containing mint"), nStatus);
+            receipt.SetStatus(strprintf(_("Unable to find transaction containing mint, txHash: %s"), mint.GetTxHash().GetHex()), nStatus);
             fArchive = true;
         } else if (mapBlockIndex.count(hashBlock) < 1) {
             receipt.SetStatus(_("Mint did not make it into blockchain"), nStatus);
@@ -4937,10 +5043,12 @@ bool CWallet::CreateZerocoinSpendTransaction(CAmount nValue, CWalletTx& wtxNew, 
         return false;
     }
 
-    if ((static_cast<int>(vSelectedMints.size()) > Params().Zerocoin_MaxSpendsPerTransaction())) {
+
+    if (static_cast<int>(vSelectedMints.size()) > nMaxSpends) {
         receipt.SetStatus(_("Failed to find coin set amongst held coins with less than maxNumber of Spends"), nStatus);
         return false;
     }
+
 
     // Create change if needed
     nStatus = ZGALI_TRX_CHANGE;
@@ -5013,8 +5121,15 @@ bool CWallet::CreateZerocoinSpendTransaction(CAmount nValue, CWalletTx& wtxNew, 
 
             //add all of the mints to the transaction as inputs
             std::vector<CTxIn> vin;
-            if (!MintsToInputVector(mapSelectedMints, hashTxOut, vin, receipt, libzerocoin::SpendType::SPEND, pindexCheckpoint))
-                return false;
+            if (isPublicSpend) {
+                if (!MintsToInputVectorPublicSpend(mapSelectedMints, hashTxOut, vin, receipt,
+                                                   libzerocoin::SpendType::SPEND, pindexCheckpoint))
+                    return false;
+            } else {
+                if (!MintsToInputVector(mapSelectedMints, hashTxOut, vin, receipt,
+                                                   libzerocoin::SpendType::SPEND, pindexCheckpoint))
+                    return false;
+            }
             txNew.vin = vin;
 
             // Limit size
@@ -5320,7 +5435,7 @@ string CWallet::MintZerocoin(CAmount nValue, CWalletTx& wtxNew, vector<CDetermin
     return "";
 }
 
-bool CWallet::SpendZerocoin(CAmount nAmount, CWalletTx& wtxNew, CZerocoinSpendReceipt& receipt, vector<CZerocoinMint>& vMintsSelected, bool fMintChange, bool fMinimizeChange, CBitcoinAddress* addressTo)
+bool CWallet::SpendZerocoin(CAmount nAmount, CWalletTx& wtxNew, CZerocoinSpendReceipt& receipt, vector<CZerocoinMint>& vMintsSelected, bool fMintChange, bool fMinimizeChange, CBitcoinAddress* addressTo, bool isPublicSpend)
 {
     // Default: assume something goes wrong. Depending on the problem this gets more specific below
     int nStatus = ZGALI_SPEND_ERROR;
@@ -5332,7 +5447,7 @@ bool CWallet::SpendZerocoin(CAmount nAmount, CWalletTx& wtxNew, CZerocoinSpendRe
 
     CReserveKey reserveKey(this);
     vector<CDeterministicMint> vNewMints;
-    if (!CreateZerocoinSpendTransaction(nAmount, wtxNew, reserveKey, receipt, vMintsSelected, vNewMints, fMintChange, fMinimizeChange, addressTo)) {
+    if (!CreateZerocoinSpendTransaction(nAmount, wtxNew, reserveKey, receipt, vMintsSelected, vNewMints, fMintChange, fMinimizeChange, addressTo, isPublicSpend)) {
         return false;
     }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2157,6 +2157,7 @@ bool CWallet::SelectStakeCoins(std::list<std::unique_ptr<CStakeInput> >& listInp
         }
     }
 
+    /* Disable zGALI Staking
     //zGALI
     if ((GetBoolArg("-zgalistake", true) || fPrecompute) && chainActive.Height() > Params().Zerocoin_Block_V2_Start() && !IsSporkActive(SPORK_16_ZEROCOIN_MAINTENANCE_MODE)) {
         //Only update zGALI set once per update interval
@@ -2186,7 +2187,7 @@ bool CWallet::SelectStakeCoins(std::list<std::unique_ptr<CStakeInput> >& listInp
             }
         }
     }
-
+    */
     return true;
 }
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -25,6 +25,7 @@
 #include "validationinterface.h"
 #include "wallet/wallet_ismine.h"
 #include "wallet/walletdb.h"
+#include "zgali/zgalimodule.h"
 #include "zgali/zgaliwallet.h"
 #include "zgali/zgalitracker.h"
 
@@ -210,14 +211,19 @@ public:
 
     // Zerocoin additions
     bool CreateZerocoinMintTransaction(const CAmount nValue, CMutableTransaction& txNew, vector<CDeterministicMint>& vDMints, CReserveKey* reservekey, int64_t& nFeeRet, std::string& strFailReason, const CCoinControl* coinControl = NULL, const bool isZCSpendChange = false);
-    bool CreateZerocoinSpendTransaction(CAmount nValue, CWalletTx& wtxNew, CReserveKey& reserveKey, CZerocoinSpendReceipt& receipt, vector<CZerocoinMint>& vSelectedMints, vector<CDeterministicMint>& vNewMints, bool fMintChange,  bool fMinimizeChange, CBitcoinAddress* address = NULL);
+    bool CreateZerocoinSpendTransaction(CAmount nValue, CWalletTx& wtxNew, CReserveKey& reserveKey, CZerocoinSpendReceipt& receipt, vector<CZerocoinMint>& vSelectedMints, vector<CDeterministicMint>& vNewMints, bool fMintChange,  bool fMinimizeChange, CBitcoinAddress* address = NULL, bool isPublicSpend = true);
     bool CheckCoinSpend(libzerocoin::CoinSpend& spend, libzerocoin::Accumulator& accumulator, CZerocoinSpendReceipt& receipt);
-    bool MintToTxIn(CZerocoinMint mint, const uint256& hashTxOut, CTxIn& newTxIn, CZerocoinSpendReceipt& receipt, libzerocoin::SpendType spendType, CBlockIndex* pindexCheckpoint = nullptr);
+    bool MintToTxIn(CZerocoinMint mint, const uint256& hashTxOut, CTxIn& newTxIn, CZerocoinSpendReceipt& receipt, libzerocoin::SpendType spendType, CBlockIndex* pindexCheckpoint = nullptr, bool publicCoinSpend = true);
     bool MintsToInputVector(std::map<CBigNum, CZerocoinMint>& mapMintsSelected, const uint256& hashTxOut, std::vector<CTxIn>& vin,
                             CZerocoinSpendReceipt& receipt, libzerocoin::SpendType spendType, CBlockIndex* pindexCheckpoint = nullptr);
+
+    // Public coin spend input creation
+    bool MintsToInputVectorPublicSpend(std::map<CBigNum, CZerocoinMint>& mapMintsSelected, const uint256& hashTxOut, std::vector<CTxIn>& vin,
+    CZerocoinSpendReceipt& receipt, libzerocoin::SpendType spendType, CBlockIndex* pindexCheckpoint = nullptr);
+
     std::string MintZerocoinFromOutPoint(CAmount nValue, CWalletTx& wtxNew, std::vector<CDeterministicMint>& vDMints, const vector<COutPoint> vOutpts);
     std::string MintZerocoin(CAmount nValue, CWalletTx& wtxNew, vector<CDeterministicMint>& vDMints, const CCoinControl* coinControl = NULL);
-    bool SpendZerocoin(CAmount nValue, CWalletTx& wtxNew, CZerocoinSpendReceipt& receipt, vector<CZerocoinMint>& vMintsSelected, bool fMintChange, bool fMinimizeChange, CBitcoinAddress* addressTo = NULL);
+    bool SpendZerocoin(CAmount nValue, CWalletTx& wtxNew, CZerocoinSpendReceipt& receipt, vector<CZerocoinMint>& vMintsSelected, bool fMintChange, bool fMinimizeChange, CBitcoinAddress* addressTo = NULL, bool isPublicSpend = true);
     std::string ResetMintZerocoin();
     std::string ResetSpentZerocoin();
     void ReconsiderZerocoins(std::list<CZerocoinMint>& listMintsRestored, std::list<CDeterministicMint>& listDMintsRestored);

--- a/src/zgali/accumulators.cpp
+++ b/src/zgali/accumulators.cpp
@@ -149,7 +149,7 @@ bool LoadAccumulatorValuesFromDB(const uint256 nCheckpoint)
         if (!zerocoinDB->ReadAccumulatorValue(nChecksum, bnValue)) {
             if (!count(listAccCheckpointsNoDB.begin(), listAccCheckpointsNoDB.end(), nCheckpoint))
                 listAccCheckpointsNoDB.push_back(nCheckpoint);
-            LogPrint("zero", "%s : Missing databased value for checksum %d", __func__, nChecksum);
+            LogPrint("zero", "%s : Missing databased value for checksum %d\n", __func__, nChecksum);
             return false;
         }
         mapAccumulatorValues.insert(make_pair(nChecksum, bnValue));

--- a/src/zgali/zerocoin.h
+++ b/src/zgali/zerocoin.h
@@ -44,6 +44,7 @@ private:
     CBigNum randomness;
     CBigNum serialNumber;
     uint256 txid;
+    int outputIndex = -1;
     CPrivKey privkey;
     uint8_t version;
     bool isUsed;
@@ -104,6 +105,9 @@ public:
     CPrivKey GetPrivKey() const { return this->privkey; }
     void SetPrivKey(const CPrivKey& privkey) { this->privkey = privkey; }
     bool GetKeyPair(CKey& key) const;
+
+    int GetOutputIndex() { return this->outputIndex; }
+    void SetOutputIndex(int index) { this->outputIndex = index; }
 
     inline bool operator <(const CZerocoinMint& a) const { return GetHeight() < a.GetHeight(); }
 

--- a/src/zgali/zgalimodule.cpp
+++ b/src/zgali/zgalimodule.cpp
@@ -1,0 +1,129 @@
+// Copyright (c) 2019 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "zgali/zgalimodule.h"
+#include "zgalichain.h"
+#include "libzerocoin/Commitment.h"
+#include "libzerocoin/Coin.h"
+#include "hash.h"
+#include "main.h"
+#include "iostream"
+
+bool PublicCoinSpend::Verify(const libzerocoin::Accumulator& a, bool verifyParams) const {
+    return validate();
+}
+
+bool PublicCoinSpend::validate() const {
+    libzerocoin::ZerocoinParams* params = Params().Zerocoin_Params(false);
+    // Check that it opens to the input values
+    libzerocoin::Commitment commitment(
+            &params->coinCommitmentGroup, getCoinSerialNumber(), randomness);
+
+    if (commitment.getCommitmentValue() != pubCoin.getValue()){
+        return error("%s: commitments values are not equal\n", __func__);
+    }
+    // Now check that the signature validates with the serial
+    if (!HasValidSignature()) {
+        return error("%s: signature invalid\n", __func__);;
+    }
+    return true;
+}
+
+const uint256 PublicCoinSpend::signatureHash() const
+{
+    CHashWriter h(0, 0);
+    h << ptxHash << denomination << getCoinSerialNumber() << randomness << txHash << outputIndex << getSpendType();
+    return h.GetHash();
+}
+
+namespace ZGALIModule {
+
+    bool createInput(CTxIn &in, CZerocoinMint &mint, uint256 hashTxOut) {
+        libzerocoin::ZerocoinParams *params = Params().Zerocoin_Params(false);
+        uint8_t nVersion = mint.GetVersion();
+        if (nVersion < libzerocoin::PrivateCoin::PUBKEY_VERSION) {
+            // No v1 serials accepted anymore.
+            return error("%s: failed to set zGALI privkey mint version=%d\n", __func__, nVersion);
+        }
+
+        CKey key;
+        if (!mint.GetKeyPair(key))
+            return error("%s: failed to set zGALI privkey mint version=%d\n", __func__, nVersion);
+
+        PublicCoinSpend spend(params, mint.GetSerialNumber(), mint.GetRandomness(), key.GetPubKey());
+        spend.setTxOutHash(hashTxOut);
+        spend.outputIndex = mint.GetOutputIndex();
+        spend.txHash = mint.GetTxHash();
+        spend.setDenom(mint.GetDenomination());
+
+        std::vector<unsigned char> vchSig;
+        if (!key.Sign(spend.signatureHash(), vchSig))
+            throw std::runtime_error("ZGALIModule failed to sign signatureHash\n");
+
+        spend.setVchSig(vchSig);
+
+        CDataStream ser(SER_NETWORK, PROTOCOL_VERSION);
+        ser << spend;
+
+        std::vector<unsigned char> data(ser.begin(), ser.end());
+        CScript scriptSigIn = CScript() << OP_ZEROCOINPUBLICSPEND << data.size();
+        scriptSigIn.insert(scriptSigIn.end(), data.begin(), data.end());
+        in = CTxIn(mint.GetTxHash(), mint.GetOutputIndex(), scriptSigIn, mint.GetDenomination());
+        in.nSequence = mint.GetDenomination();
+        return true;
+    }
+
+    bool parseCoinSpend(const CTxIn &in, const CTransaction &tx, const CTxOut &prevOut, PublicCoinSpend &publicCoinSpend) {
+        if (!in.IsZerocoinPublicSpend() || !prevOut.IsZerocoinMint())
+            return error("%s: invalid argument/s\n", __func__);
+
+        std::vector<char, zero_after_free_allocator<char> > data;
+        data.insert(data.end(), in.scriptSig.begin() + 4, in.scriptSig.end());
+        CDataStream serializedCoinSpend(data, SER_NETWORK, PROTOCOL_VERSION);
+        libzerocoin::ZerocoinParams *params = Params().Zerocoin_Params(false);
+        PublicCoinSpend spend(params, serializedCoinSpend);
+
+        spend.outputIndex = in.prevout.n;
+        spend.txHash = in.prevout.hash;
+        CMutableTransaction txNew(tx);
+        txNew.vin.clear();
+        spend.setTxOutHash(txNew.GetHash());
+
+        // Check prev out now
+        CValidationState state;
+        if (!TxOutToPublicCoin(prevOut, spend.pubCoin, state))
+            return error("%s: cannot get mint from output\n", __func__);
+
+        spend.setDenom(spend.pubCoin.getDenomination());
+        publicCoinSpend = spend;
+        return true;
+    }
+
+    bool validateInput(const CTxIn &in, const CTxOut &prevOut, const CTransaction &tx, PublicCoinSpend &publicSpend) {
+        // Now prove that the commitment value opens to the input
+        if (!parseCoinSpend(in, tx, prevOut, publicSpend)) {
+            return false;
+        }
+        if (libzerocoin::ZerocoinDenominationToAmount(
+                libzerocoin::IntToZerocoinDenomination(in.nSequence)) != prevOut.nValue) {
+            return error("PublicCoinSpend validateInput :: input nSequence different to prevout value\n");
+        }
+
+        return publicSpend.validate();
+    }
+
+    bool ParseZerocoinPublicSpend(const CTxIn &txIn, const CTransaction& tx, CValidationState& state, PublicCoinSpend& publicSpend)
+    {
+        CTxOut prevOut;
+        if(!GetOutput(txIn.prevout.hash, txIn.prevout.n ,state, prevOut)){
+            return state.DoS(100, error("%s: public zerocoin spend prev output not found, prevTx %s, index %d\n",
+                                        __func__, txIn.prevout.hash.GetHex(), txIn.prevout.n));
+        }
+        if (!ZGALIModule::parseCoinSpend(txIn, tx, prevOut, publicSpend)) {
+            return state.Invalid(error("%s: invalid public coin spend parse %s\n", __func__,
+                                       tx.GetHash().GetHex()), REJECT_INVALID, "bad-txns-invalid-zgali");
+        }
+        return true;
+    }
+}

--- a/src/zgali/zgalimodule.h
+++ b/src/zgali/zgalimodule.h
@@ -1,0 +1,90 @@
+// Copyright (c) 2019 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+//
+#ifndef GALI_ZGALIMODULE_H
+#define GALI_ZGALIMODULE_H
+
+#include "libzerocoin/bignum.h"
+#include "libzerocoin/Denominations.h"
+#include "libzerocoin/CoinSpend.h"
+#include "libzerocoin/Coin.h"
+#include "libzerocoin/SpendType.h"
+#include "primitives/transaction.h"
+#include "script/script.h"
+#include "serialize.h"
+#include "uint256.h"
+#include <streams.h>
+#include <utilstrencodings.h>
+#include "zgali/zerocoin.h"
+#include "chainparams.h"
+
+static int const COIN_SPEND_PUBLIC_SPEND_VERSION = 3;
+
+class PublicCoinSpend : public libzerocoin::CoinSpend{
+public:
+
+    PublicCoinSpend(libzerocoin::ZerocoinParams* params):pubCoin(params){};
+
+    PublicCoinSpend(libzerocoin::ZerocoinParams* params,
+            CBigNum serial, CBigNum randomness, CPubKey pubkey):pubCoin(params){
+        this->coinSerialNumber = serial;
+        this->randomness = randomness;
+        this->pubkey = pubkey;
+        this->spendType = libzerocoin::SpendType::SPEND;
+        this->version = COIN_SPEND_PUBLIC_SPEND_VERSION;
+    };
+
+    template <typename Stream>
+    PublicCoinSpend(
+            libzerocoin::ZerocoinParams* params,
+            Stream& strm):pubCoin(params){
+        strm >> *this;
+        this->spendType = libzerocoin::SpendType::SPEND;
+    }
+
+    const uint256 signatureHash() const override;
+    void setVchSig(std::vector<unsigned char> vchSig) { this->vchSig = vchSig; };
+    bool Verify(const libzerocoin::Accumulator& a, bool verifyParams = true) const override;
+    bool validate() const;
+
+    // Members
+    CBigNum randomness;
+    // prev out values
+    uint256 txHash = 0;
+    unsigned int outputIndex = -1;
+    libzerocoin::PublicCoin pubCoin;
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+        READWRITE(version);
+        READWRITE(coinSerialNumber);
+        READWRITE(randomness);
+        READWRITE(pubkey);
+        READWRITE(vchSig);
+    }
+};
+
+
+class CValidationState;
+
+namespace ZGALIModule {
+    bool createInput(CTxIn &in, CZerocoinMint& mint, uint256 hashTxOut);
+    bool parseCoinSpend(const CTxIn &in, const CTransaction& tx, const CTxOut &prevOut, PublicCoinSpend& publicCoinSpend);
+    bool validateInput(const CTxIn &in, const CTxOut &prevOut, const CTransaction& tx, PublicCoinSpend& ret);
+
+    // Public zc spend parse
+    /**
+     *
+     * @param in --> public zc spend input
+     * @param tx --> input parent
+     * @param publicCoinSpend ---> return the publicCoinSpend parsed
+     * @return true if everything went ok
+     */
+    bool ParseZerocoinPublicSpend(const CTxIn &in, const CTransaction& tx, CValidationState& state, PublicCoinSpend& publicCoinSpend);
+};
+
+
+#endif //GALI_ZGALIMODULE_H

--- a/src/zgali/zgalitracker.cpp
+++ b/src/zgali/zgalitracker.cpp
@@ -462,7 +462,7 @@ bool CzGALITracker::UpdateStatusInternal(const std::set<uint256>& setMempool, CM
     return false;
 }
 
-std::set<CMintMeta> CzGALITracker::ListMints(bool fUnusedOnly, bool fMatureOnly, bool fUpdateStatus, bool fWrongSeed)
+std::set<CMintMeta> CzGALITracker::ListMints(bool fUnusedOnly, bool fMatureOnly, bool fUpdateStatus, bool fWrongSeed, bool fExcludeV1)
 {
     CWalletDB walletdb(strWalletFile);
     if (fUpdateStatus) {
@@ -475,6 +475,8 @@ std::set<CMintMeta> CzGALITracker::ListMints(bool fUnusedOnly, bool fMatureOnly,
 
         CzGALIWallet* zGALIWallet = new CzGALIWallet(strWalletFile);
         for (auto& dMint : listDeterministicDB) {
+            if (fExcludeV1 && dMint.GetVersion() < 2)
+                continue;
             Add(dMint, false, false, zGALIWallet);
         }
         delete zGALIWallet;

--- a/src/zgali/zgalitracker.h
+++ b/src/zgali/zgalitracker.h
@@ -47,7 +47,7 @@ public:
     bool ClearSpendCache() EXCLUSIVE_LOCKS_REQUIRED(cs_spendcache);
     std::vector<CMintMeta> GetMints(bool fConfirmedOnly) const;
     CAmount GetUnconfirmedBalance() const;
-    std::set<CMintMeta> ListMints(bool fUnusedOnly, bool fMatureOnly, bool fUpdateStatus, bool fWrongSeed = false);
+    std::set<CMintMeta> ListMints(bool fUnusedOnly, bool fMatureOnly, bool fUpdateStatus, bool fWrongSeed = false, bool fExcludeV1 = false);
     void RemovePending(const uint256& txid);
     void SetPubcoinUsed(const uint256& hashPubcoin, const uint256& txid);
     void SetPubcoinNotUsed(const uint256& hashPubcoin);

--- a/test/functional/fake_stake/base_test.py
+++ b/test/functional/fake_stake/base_test.py
@@ -48,7 +48,9 @@ class GALI_FakeStakeTest(BitcoinTestFramework):
         :param:
         :return:
         '''
-        self.log.info("\n\n*** Starting %s ***\n------------------------\n%s\n", self.__class__.__name__, self.description)
+        title = "*** Starting %s ***" % self.__class__.__name__
+        underline = "-" * len(title)
+        self.log.info("\n\n%s\n%s\n%s\n", title, underline, self.description)
         # Global Test parameters (override in run_test)
         self.DEFAULT_FEE = 0.1
         # Spam blocks to send in current test
@@ -92,8 +94,6 @@ class GALI_FakeStakeTest(BitcoinTestFramework):
         :return  block:              (CBlock) generated block
         '''
 
-        self.log.info("Creating Spam Block")
-
         # If not given inputs to create spam txes, use a copy of the staking inputs
         if len(spendingPrevOuts) == 0:
             spendingPrevOuts = dict(stakingPrevOuts)
@@ -117,8 +117,6 @@ class GALI_FakeStakeTest(BitcoinTestFramework):
         if not block.solve_stake(stakingPrevOuts):
             raise Exception("Not able to solve for any prev_outpoint")
 
-        self.log.info("Stake found. Signing block...")
-
         # Sign coinstake TX and add it to the block
         signed_stake_tx = self.sign_stake_tx(block, stakingPrevOuts[block.prevoutStake][0], fZPoS)
         block.vtx.append(signed_stake_tx)
@@ -130,10 +128,10 @@ class GALI_FakeStakeTest(BitcoinTestFramework):
 
         # remove a random prevout from the list
         # (to randomize block creation if the same height is picked two times)
-        del spendingPrevOuts[choice(list(spendingPrevOuts))]
+        if len(spendingPrevOuts) > 0:
+            del spendingPrevOuts[choice(list(spendingPrevOuts))]
 
         # Create spam for the block. Sign the spendingPrevouts
-        self.log.info("Creating spam TXes...")
         for outPoint in spendingPrevOuts:
             value_out = int(spendingPrevOuts[outPoint][0] - self.DEFAULT_FEE * COIN)
             tx = create_transaction(outPoint, b"", value_out, nTime, scriptPubKey=CScript([self.block_sig_key.get_pubkey(), OP_CHECKSIG]))

--- a/test/functional/zerocoin_publicSpend_reorg.py
+++ b/test/functional/zerocoin_publicSpend_reorg.py
@@ -1,0 +1,208 @@
+# !/usr/bin/env python3
+# Copyright (c) 2019 The PIVX Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+'''
+Covers the scenario of two valid PoS blocks with same height
+and same coinstake input.
+'''
+
+from copy import deepcopy
+from io import BytesIO
+import time
+from test_framework.messages import CTransaction, CBlock
+from test_framework.util import bytes_to_hex_str, hex_str_to_bytes, assert_equal
+from fake_stake.base_test import GALI_FakeStakeTest
+
+
+class ZerocoinPublicSpendReorg(GALI_FakeStakeTest):
+
+    def run_test(self):
+        self.description = "Covers the reorg with a zc public spend in vtx"
+        self.init_test()
+        DENOM_TO_USE = 10           # zc denomination
+        INITAL_MINED_BLOCKS = 321   # First mined blocks (rewards collected to mint)
+        MORE_MINED_BLOCKS = 105     # More blocks mined before spending zerocoins
+
+        # 1) Starting mining blocks
+        self.log.info("Mining %d blocks.." % INITAL_MINED_BLOCKS)
+        self.node.generate(INITAL_MINED_BLOCKS)
+
+        # 2) Mint 2 zerocoins
+        self.node.mintzerocoin(DENOM_TO_USE)
+        self.node.generate(1)
+        self.node.mintzerocoin(DENOM_TO_USE)
+        self.node.generate(1)
+
+        # 3) Mine additional blocks and collect the mints
+        self.log.info("Mining %d blocks.." % MORE_MINED_BLOCKS)
+        self.node.generate(MORE_MINED_BLOCKS)
+        self.log.info("Collecting mints...")
+        mints = self.node.listmintedzerocoins(True, False)
+        assert len(mints) == 2, "mints list has len %d (!= 2)" % len(mints)
+
+        # 4) Get unspent coins and chain tip
+        self.unspent = self.node.listunspent()
+        block_count = self.node.getblockcount()
+        pastBlockHash = self.node.getblockhash(block_count)
+        self.log.info("Block count: %d - Current best: %s..." % (self.node.getblockcount(), self.node.getbestblockhash()[:5]))
+        pastBlock = CBlock()
+        pastBlock.deserialize(BytesIO(hex_str_to_bytes(self.node.getblock(pastBlockHash, False))))
+        checkpoint = pastBlock.nAccumulatorCheckpoint
+
+        # 5) get the raw zerocoin spend txes
+        self.log.info("Getting the raw zerocoin public spends...")
+        public_spend_A = self.node.createrawzerocoinpublicspend(mints[0].get("serial hash"))
+        tx_A = CTransaction()
+        tx_A.deserialize(BytesIO(hex_str_to_bytes(public_spend_A)))
+        tx_A.rehash()
+        public_spend_B = self.node.createrawzerocoinpublicspend(mints[1].get("serial hash"))
+        tx_B = CTransaction()
+        tx_B.deserialize(BytesIO(hex_str_to_bytes(public_spend_B)))
+        tx_B.rehash()
+        # Spending same coins to different recipients to get different txids
+        my_addy = "yAVWM5urwaTyhiuFQHP2aP47rdZsLUG5PH"
+        public_spend_A2 = self.node.createrawzerocoinpublicspend(mints[0].get("serial hash"), my_addy)
+        tx_A2 = CTransaction()
+        tx_A2.deserialize(BytesIO(hex_str_to_bytes(public_spend_A2)))
+        tx_A2.rehash()
+        public_spend_B2 = self.node.createrawzerocoinpublicspend(mints[1].get("serial hash"), my_addy)
+        tx_B2 = CTransaction()
+        tx_B2.deserialize(BytesIO(hex_str_to_bytes(public_spend_B2)))
+        tx_B2.rehash()
+        self.log.info("tx_A id: %s" % str(tx_A.hash))
+        self.log.info("tx_B id: %s" % str(tx_B.hash))
+        self.log.info("tx_A2 id: %s" % str(tx_A2.hash))
+        self.log.info("tx_B2 id: %s" % str(tx_B2.hash))
+
+
+        self.test_nodes[0].handle_connect()
+
+        # 6) create block_A --> main chain
+        self.log.info("")
+        self.log.info("*** block_A ***")
+        self.log.info("Creating block_A [%d] with public spend tx_A in it." % (block_count + 1))
+        block_A = self.new_block(block_count, pastBlock, checkpoint, tx_A)
+        self.log.info("Hash of block_A: %s..." % block_A.hash[:5])
+        self.log.info("sending block_A...")
+        var = self.node.submitblock(bytes_to_hex_str(block_A.serialize()))
+        if var is not None:
+            self.log.info("result: %s" % str(var))
+            raise Exception("block_A not accepted")
+        time.sleep(2)
+        assert_equal(self.node.getblockcount(), block_count+1)
+        assert_equal(self.node.getbestblockhash(), block_A.hash)
+        self.log.info("  >>  block_A connected  <<")
+        self.log.info("Current chain: ... --> block_0 [%d] --> block_A [%d]\n" % (block_count, block_count+1))
+
+        # 7) create block_B --> forked chain
+        self.log.info("*** block_B ***")
+        self.log.info("Creating block_B [%d] with public spend tx_B in it." % (block_count + 1))
+        block_B = self.new_block(block_count, pastBlock, checkpoint, tx_B)
+        self.log.info("Hash of block_B: %s..." % block_B.hash[:5])
+        self.log.info("sending block_B...")
+        var = self.node.submitblock(bytes_to_hex_str(block_B.serialize()))
+        self.log.info("result of block_B submission: %s" % str(var))
+        time.sleep(2)
+        assert_equal(self.node.getblockcount(), block_count+1)
+        assert_equal(self.node.getbestblockhash(), block_A.hash)
+        # block_B is not added. Chain remains the same
+        self.log.info("  >>  block_B not connected  <<")
+        self.log.info("Current chain: ... --> block_0 [%d] --> block_A [%d]\n" % (block_count, block_count+1))
+
+        # 8) Create new block block_C on the forked chain (block_B)
+        block_count += 1
+        self.log.info("*** block_C ***")
+        self.log.info("Creating block_C [%d] on top of block_B triggering the reorg" % (block_count + 1))
+        block_C = self.new_block(block_count, block_B, checkpoint)
+        self.log.info("Hash of block_C: %s..." % block_C.hash[:5])
+        self.log.info("sending block_C...")
+        var = self.node.submitblock(bytes_to_hex_str(block_C.serialize()))
+        if var is not None:
+            self.log.info("result: %s" % str(var))
+            raise Exception("block_C not accepted")
+        time.sleep(2)
+        assert_equal(self.node.getblockcount(), block_count+1)
+        assert_equal(self.node.getbestblockhash(), block_C.hash)
+        self.log.info("  >>  block_A disconnected / block_B and block_C connected  <<")
+        self.log.info("Current chain: ... --> block_0 [%d] --> block_B [%d] --> block_C [%d]\n" % (
+                block_count - 1, block_count, block_count+1
+        ))
+
+        # 7) Now create block_D which tries to spend same coin of tx_B again on the (new) main chain
+        # (this block will be rejected)
+        block_count += 1
+        self.log.info("*** block_D ***")
+        self.log.info("Creating block_D [%d] trying to double spend the coin of tx_B" % (block_count + 1))
+        block_D = self.new_block(block_count, block_C, checkpoint, tx_B2)
+        self.log.info("Hash of block_D: %s..." % block_D.hash[:5])
+        self.log.info("sending block_D...")
+        var = self.node.submitblock(bytes_to_hex_str(block_D.serialize()))
+        self.log.info("result of block_D submission: %s" % str(var))
+        time.sleep(2)
+        assert_equal(self.node.getblockcount(), block_count)
+        assert_equal(self.node.getbestblockhash(), block_C.hash)
+        # block_D is not added. Chain remains the same
+        self.log.info("  >>  block_D rejected  <<")
+        self.log.info("Current chain: ... --> block_0 [%d] --> block_B [%d] --> block_C [%d]\n" % (
+                block_count - 2, block_count - 1, block_count
+        ))
+
+        # 8) Now create block_E which spends tx_A again on main chain
+        # (this block will be accepted and connected since tx_A was spent on block_A now disconnected)
+        self.log.info("*** block_E ***")
+        self.log.info("Creating block_E [%d] trying spend tx_A on main chain" % (block_count + 1))
+        block_E = self.new_block(block_count, block_C, checkpoint, tx_A)
+        self.log.info("Hash of block_E: %s..." % block_E.hash[:5])
+        self.log.info("sending block_E...")
+        var = self.node.submitblock(bytes_to_hex_str(block_E.serialize()))
+        if var is not None:
+            self.log.info("result: %s" % str(var))
+            raise Exception("block_E not accepted")
+        time.sleep(2)
+        assert_equal(self.node.getblockcount(), block_count+1)
+        assert_equal(self.node.getbestblockhash(), block_E.hash)
+        self.log.info("  >>  block_E connected <<")
+        self.log.info("Current chain: ... --> block_0 [%d] --> block_B [%d] --> block_C [%d] --> block_E [%d]\n" % (
+                block_count - 2, block_count - 1, block_count, block_count+1
+        ))
+
+        # 9) Now create block_F which tries to double spend the coin in tx_A
+        # # (this block will be rejected)
+        block_count += 1
+        self.log.info("*** block_F ***")
+        self.log.info("Creating block_F [%d] trying to double spend the coin in tx_A" % (block_count + 1))
+        block_F = self.new_block(block_count, block_E, checkpoint, tx_A2)
+        self.log.info("Hash of block_F: %s..." % block_F.hash[:5])
+        self.log.info("sending block_F...")
+        var = self.node.submitblock(bytes_to_hex_str(block_F.serialize()))
+        self.log.info("result of block_F submission: %s" % str(var))
+        time.sleep(2)
+        assert_equal(self.node.getblockcount(), block_count)
+        assert_equal(self.node.getbestblockhash(), block_E.hash)
+        self.log.info("  >>  block_F rejected <<")
+        self.log.info("Current chain: ... --> block_0 [%d] --> block_B [%d] --> block_C [%d] --> block_E [%d]\n" % (
+                block_count - 3, block_count - 2, block_count - 1, block_count
+        ))
+        self.log.info("All good.")
+
+
+
+    def new_block(self, block_count, prev_block, checkpoint, zcspend = None):
+        if prev_block.hash is None:
+            prev_block.rehash()
+        staking_utxo_list = [self.unspent.pop()]
+        pastBlockHash = prev_block.hash
+        stakingPrevOuts = self.get_prevouts(staking_utxo_list, block_count)
+        block = self.create_spam_block(pastBlockHash, stakingPrevOuts, block_count + 1)
+        if zcspend is not None:
+            block.vtx.append(zcspend)
+            block.hashMerkleRoot = block.calc_merkle_root()
+        block.nAccumulatorCheckpoint = checkpoint
+        block.rehash()
+        block.sign_block(self.block_sig_key)
+        return block
+
+if __name__ == '__main__':
+    ZerocoinPublicSpendReorg().main()

--- a/test/functional/zerocoin_valid_public_spend.py
+++ b/test/functional/zerocoin_valid_public_spend.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+# Copyright (c) 2019 The PIVX Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+'''
+Covers the 'Wrapped Serials Attack' scenario
+'''
+
+import random
+from time import sleep
+
+from test_framework.authproxy import JSONRPCException
+from test_framework.util import assert_equal, assert_greater_than
+
+from fake_stake.base_test import GALI_FakeStakeTest
+
+class zGALIValidCoinSpendTest(GALI_FakeStakeTest):
+
+    def run_test(self):
+        self.description = "Covers the 'valid publicCoinSpend spend' scenario."
+        self.init_test()
+
+        INITAL_MINED_BLOCKS = 301   # Blocks mined before minting
+        MORE_MINED_BLOCKS = 52      # Blocks mined after minting (before spending)
+        DENOM_TO_USE = 1         # zc denomination used for double spending attack
+
+        # 1) Start mining blocks
+        self.log.info("Mining %d first blocks..." % INITAL_MINED_BLOCKS)
+        self.node.generate(INITAL_MINED_BLOCKS)
+        sleep(2)
+
+        # 2) Mint zerocoins
+        self.log.info("Minting %d-denom zGALIs..." % DENOM_TO_USE)
+        self.node.mintzerocoin(DENOM_TO_USE)
+        self.node.generate(1)
+        sleep(2)
+        self.node.mintzerocoin(DENOM_TO_USE)
+        sleep(2)
+
+        # 3) Mine more blocks and collect the mint
+        self.log.info("Mining %d more blocks..." % MORE_MINED_BLOCKS)
+        self.node.generate(MORE_MINED_BLOCKS)
+        sleep(2)
+        list = self.node.listmintedzerocoins(True, True)
+        mint = list[0]
+
+        # 4) Get the raw zerocoin data
+        exported_zerocoins = self.node.exportzerocoins(False)
+        zc = [x for x in exported_zerocoins if mint["serial hash"] == x["id"]]
+        if len(zc) == 0:
+            raise AssertionError("mint not found")
+
+        # 5) Spend the minted coin (mine six more blocks)
+        self.log.info("Spending the minted coin with serial %s and mining six more blocks..." % zc[0]["s"])
+        txid = self.node.spendzerocoinmints([mint["serial hash"]])['txid']
+        self.log.info("Spent on tx %s" % txid)
+        self.node.generate(6)
+        sleep(2)
+
+        rawTx = self.node.getrawtransaction(txid, 1)
+        if rawTx is None:
+            self.log.warning("rawTx is: %s" % rawTx)
+            raise AssertionError("TEST FAILED")
+        else:
+            assert (rawTx["confirmations"] == 6)
+
+        self.log.info("%s VALID PUBLIC COIN SPEND PASSED" % self.__class__.__name__)
+
+        self.log.info("%s Trying to spend the serial twice now" % self.__class__.__name__)
+
+        serial = zc[0]["s"]
+        randomness = zc[0]["r"]
+        privkey = zc[0]["k"]
+
+        tx = None
+        try:
+            tx = self.node.spendrawzerocoin(serial, randomness, DENOM_TO_USE, privkey)
+        except JSONRPCException as e:
+            self.log.info("GOOD: Transaction did not verify")
+
+        if tx is not None:
+            self.log.warning("Tx is: %s" % tx)
+            raise AssertionError("TEST FAILED")
+
+        self.log.info("%s DOUBLE SPENT SERIAL NOT VERIFIED, TEST PASSED" % self.__class__.__name__)
+
+        self.log.info("%s Trying to spend using the old coin spend method.." % self.__class__.__name__)
+
+        tx = None
+        try:
+            tx = self.node.spendzerocoin(DENOM_TO_USE, False, False, "", False)
+            raise AssertionError("TEST FAILED, old coinSpend spent")
+        except JSONRPCException as e:
+            self.log.info("GOOD: spendzerocoin old spend did not verify")
+
+
+        self.log.info("%s OLD COIN SPEND NON USABLE ANYMORE, TEST PASSED" % self.__class__.__name__)
+
+
+if __name__ == '__main__':
+    zGALIValidCoinSpendTest().main()


### PR DESCRIPTION
Recent exploit in the Zerocoin protocol (broken P1 proof) forced us to deactivate zGALI functionality to secure the supply until an upstream fix is available. This PR mitigates this situation by removing the privacy part of Zerocoin. It is far from ideal since all zGALI spends are public, but unlocks zGALI supply.

You can find more information on the vulnerability at: https://zcoin.io/cryptographic-description-of-zerocoin-attack/ and in the PR request to [PIVX/891](https://github.com/PIVX-Project/PIVX/pull/891). Many thanks to @random-zebra and @furszy for this patchset.