### PR TITLE
Zerocoin public spend activation and RISC-V build fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,7 @@ jobs:
         - set -o errexit; source .travis/lint_06_script.sh
 
     - stage: test
-      name: 'ARM 32-bit  [GOAL: install]  [no unit or functional tests]'
+      name: 'ARM 32-bit [GOAL: install] [no unit or functional tests]'
       env: >-
         HOST=arm-linux-gnueabihf
         PACKAGES="python3 g++-arm-linux-gnueabihf curl"
@@ -98,7 +98,7 @@ jobs:
         BITCOIN_CONFIG="--enable-glibc-back-compat --enable-reduce-exports CXXFLAGS=-Wno-psabi"
 
     - stage: test
-      name: 'ARM 64-bit  [GOAL:install] [no unit or functional tests]'
+      name: 'ARM 64-bit [GOAL: install] [no unit or functional tests]'
       env: >-
         HOST=aarch64-linux-gnu
         PACKAGES="python3 g++-aarch64-linux-gnu curl"
@@ -108,7 +108,7 @@ jobs:
         BITCOIN_CONFIG="--enable-glibc-back-compat --enable-reduce-exports"
 
     - stage: test
-      name: 'Win32  [GOAL: deploy] [no functional tests]'
+      name: 'Win32 [GOAL: deploy] [no functional tests]'
       env: >-
         HOST=i686-w64-mingw32
         DPKG_ADD_ARCH="i386"
@@ -118,7 +118,7 @@ jobs:
         BITCOIN_CONFIG="--enable-reduce-exports"
 
     - stage: test
-      name: 'Win64  [GOAL: deploy] [no functional tests]'
+      name: 'Win64 [GOAL: deploy] [no functional tests]'
       env: >-
         HOST=x86_64-w64-mingw32
         PACKAGES="python3 nsis g++-mingw-w64-x86-64 wine-binfmt wine64 curl"
@@ -127,7 +127,7 @@ jobs:
         BITCOIN_CONFIG="--enable-reduce-exports"
 
     - stage: test
-      name: '32-bit + dash  [GOAL: install] [no gui]'
+      name: '32-bit + dash [GOAL: install] [no gui]'
       env: >-
         HOST=i686-pc-linux-gnu
         PACKAGES="g++-multilib python3-zmq curl"
@@ -136,7 +136,7 @@ jobs:
         CONFIG_SHELL="/bin/dash"
 
     - stage: test
-      name: 'x86_64 Linux  [GOAL: install]  [bionic]  [uses qt5 dev package instead of depends Qt to speed up build and avoid timeout]'
+      name: 'x86_64 Linux [GOAL: install] [bionic] [uses qt5 dev package instead of depends Qt to speed up build and avoid timeout]'
       env: >-
         HOST=x86_64-unknown-linux-gnu
         PACKAGES="python3-zmq qtbase5-dev qttools5-dev-tools protobuf-compiler libdbus-1-dev libharfbuzz-dev libprotobuf-dev libcurl4-openssl-dev curl"
@@ -147,7 +147,7 @@ jobs:
         BITCOIN_CONFIG="--enable-zmq --with-gui=qt5 --enable-glibc-back-compat --enable-reduce-exports"
 
     - stage: test
-      name: 'x86_64 Linux  [GOAL: install]  [trusty]  [no functional tests, no depends, only system libs]'
+      name: 'x86_64 Linux [GOAL: install] [trusty] [no functional tests, no depends, only system libs]'
       env: >-
         HOST=x86_64-unknown-linux-gnu
         DOCKER_NAME_TAG=ubuntu:14.04
@@ -158,7 +158,7 @@ jobs:
         BITCOIN_CONFIG="--enable-zmq --with-incompatible-bdb --with-gui=no"
 
     - stage: test
-      name: 'x86_64 Linux  [GOAL: install]  [xenial]  [no depends, only system libs]'
+      name: 'x86_64 Linux [GOAL: install] [xenial] [no depends, only system libs]'
       env: >-
         HOST=x86_64-unknown-linux-gnu
         DOCKER_NAME_TAG=ubuntu:16.04
@@ -168,7 +168,7 @@ jobs:
         BITCOIN_CONFIG="--enable-zmq --with-incompatible-bdb --with-gui=qt5 CPPFLAGS=-DDEBUG_LOCKORDER --disable-hardening --disable-asm"
 
     - stage: test
-      name: 'x86_64 Linux  [GOAL: install]  [bionic]  [no depends, only system libs]'
+      name: 'x86_64 Linux [GOAL: install] [bionic] [no depends, only system libs]'
       env: >-
         HOST=x86_64-unknown-linux-gnu
         PACKAGES="python3-zmq qtbase5-dev qttools5-dev-tools libssl1.0-dev libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-program-options-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev libzmq3-dev libprotobuf-dev protobuf-compiler libqrencode-dev libgmp-dev libcurl-openssl1.0-dev"
@@ -177,7 +177,7 @@ jobs:
         BITCOIN_CONFIG="--enable-zmq --with-incompatible-bdb --with-gui=qt5 CPPFLAGS=-DDEBUG_LOCKORDER"
 
 #    - stage: test
-#      name: 'x86_64 Linux  [GOAL: install]  [bionic]  [no depends, only system libs, sanitizers: fuzzer,address]'
+#      name: 'x86_64 Linux [GOAL: install] [bionic] [no depends, only system libs, sanitizers: fuzzer,address]'
 #      env: >-
 #        HOST=x86_64-unknown-linux-gnu
 #        PACKAGES="clang python3-zmq qtbase5-dev qttools5-dev-tools libssl1.0-dev libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-program-options-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev libzmq3-dev libprotobuf-dev protobuf-compiler libqrencode-dev libgmp-dev libcurl-openssl1.0-dev"
@@ -189,7 +189,7 @@ jobs:
 #        BITCOIN_CONFIG="--enable-zmq --with-incompatible-bdb --enable-glibc-back-compat --enable-reduce-exports --with-gui=qt5 CPPFLAGS=-DDEBUG_LOCKORDER --with-sanitizers=undefined CC=clang CXX=clang++"
 
 #    - stage: test
-#      name: 'x86_64 Linux  [GOAL: install]  [bionic]  [no wallet]'
+#      name: 'x86_64 Linux [GOAL: install] [bionic] [no wallet]'
 #      env: >-
 #        HOST=x86_64-unknown-linux-gnu
 #        PACKAGES="python3-zmq curl"
@@ -198,7 +198,7 @@ jobs:
 #        BITCOIN_CONFIG="--enable-glibc-back-compat --enable-reduce-exports"
 
     - stage: test
-      name: 'macOS 10.10  [GOAL: deploy] [no functional tests]'
+      name: 'macOS 10.10 [GOAL: deploy] [no functional tests]'
       env: >-
         HOST=x86_64-apple-darwin14
         PACKAGES="cmake imagemagick libcap-dev librsvg2-bin libz-dev libbz2-dev libtiff-tools python3-dev python3-setuptools curl"

--- a/depends/packages/libcurl.mk
+++ b/depends/packages/libcurl.mk
@@ -4,6 +4,7 @@ $(package)_download_path=https://curl.haxx.se/download
 $(package)_file_name=curl-$(libcurl_version).tar.bz2
 $(package)_sha256_hash=b5920ffd6a8c95585fb95070e0ced38322790cb335c39d0dab852d12e157b5a0
 $(package)_dependencies=openssl
+$(package)_cflags_linux=-fPIC
 
 define $(package)_set_vars
 $(package)_config_opts=--disable-shared --with-ssl

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -145,7 +145,7 @@ public:
         nRejectOldSporkKey = 1554080400;		/* Mon Apr  1 01:00:00 UTC 2019: after that reject old spork key */
 
         // Public coin spend enforcement
-        nPublicZCSpends = 626000;
+        nPublicZCSpends = 681000;
 
         /**
          * Build the genesis block. Note that the output of the genesis coinbase cannot


### PR DESCRIPTION
This PR include final Zerocoin public spend activation block and RISC-V build fix for ``libcurl.a(libcurl_la-easy.o): relocation R_RISCV_HI20 against `a local symbol' can not be used when making a shared object; recompile with -fPIC``. We added libcurl to dependencies for cloud bootstrap but forgot about proper library building.